### PR TITLE
Removing calls to toBuffer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "wa-map-optimizer",
-    "version": "1.4.2",
+    "version": "1.4.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "wa-map-optimizer",
-            "version": "1.4.2",
+            "version": "1.4.3",
             "license": "AGPL-3.0",
             "dependencies": {
                 "@workadventure/tiled-map-type-guard": "^2.1.1",

--- a/src/Optimizer.ts
+++ b/src/Optimizer.ts
@@ -59,7 +59,9 @@ export class Optimizer {
 
         await this.optimizeNamedTiles();
 
-        await this.currentTilesetRendering();
+        if (this.currentExtractedTiles.length > 0) {
+            await this.currentTilesetRendering();
+        }
 
         this.optimizedMap.tilesets = [];
 


### PR DESCRIPTION
As much as possible, limiting the number of calls to "toBuffer". The image should remain in the same format all the way.