### PR TITLE
feat!: guarantee one tileset per layer for Phaser 4 TilemapGPULayer

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 dist
 example
+tests

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -37,3 +37,6 @@ jobs:
 
       - name: "Lint"
         run: npm run lint
+
+      - name: "Test"
+        run: npm test

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ async function run() {
           tileset: {
             prefix: "optimized",
             suffix: "tileset",
+            // Maximum size (in pixels) of an output tileset texture.
+            // Must be a power of 2. Default: 4096.
             size: 1024,
           }
       }
@@ -65,12 +67,33 @@ run();
 This package will optimize your Tiled map by removing unused tiles and creating a new tileset 
 with only the used tiles. It will also update the map to use the new tileset.
 
-At a high level, the optimizer walks every tile layer of the map (recursing into group layers),
-collects the set of tiles that are actually referenced, extracts only those tiles from the source
-tilesets and re-packs them into new, tightly-packed tileset images. The map data is then rewritten
-in place so every tile reference points to its new location, and the source tilesets are discarded.
+A detailed, step-by-step description of the algorithm is available in
+[docs/algorithm.md](docs/algorithm.md).
+
+At a high level, the optimizer works in three passes:
+
+1. **Analysis**: walk every tile layer of the map (recursing into group layers) and collect the set
+   of tiles each layer actually references.
+2. **Clustering**: group layers so that each group's tiles fit together in a single tileset texture.
+3. **Rendering**: extract the tiles from the source tilesets, re-pack them into one new tileset
+   image per group, and rewrite the map data so every tile reference points to its new location.
+   The source tilesets are discarded.
 
 Rules:
+
+- **Each layer references a single tileset.** This is the requirement for Phaser 4's
+  `TilemapGPULayer`: a GPU-rendered layer must source all of its tiles from one tileset. The
+  optimizer guarantees it by construction — layers are clustered, and each cluster produces exactly
+  one tileset holding the union of its layers' tiles. A tileset may be shared by several layers,
+  and a tile used by layers living in different clusters is duplicated into both tilesets (the
+  clustering minimizes how often this happens).
+- **Tileset textures have power-of-2 dimensions.** Output images are rectangular power-of-2
+  textures (e.g. 2048x1024), as close to square as possible, capped at a configurable maximum size
+  (`output.tileset.size`, default `4096`). The clustering packs as many layers as possible into
+  each texture within that cap.
+- **A single layer bigger than one tileset is never split.** If one layer alone uses more tiles
+  than fit in the maximum texture size, the optimizer warns and renders that layer with several
+  tilesets: the map stays correct, but that layer will not be eligible for GPU rendering.
 
 - **Only referenced tiles are kept.** Tiles that are never placed on any tile layer are dropped
   from the output. Empty tiles (id `0`) are ignored.
@@ -82,16 +105,12 @@ Rules:
   the new id.
 - **Animated tiles are kept whole.** When a tile is animated, all of its animation frames are pulled
   into the output (even frames that are never placed directly on the map), and the whole animation is
-  guaranteed to stay within a single tileset — the current tileset is flushed early rather than
-  splitting an animation across two of them. Frame references are rewritten to the new local ids.
+  guaranteed to stay within the same tileset as its base tile (frame ids are tileset-local in the
+  Tiled format). Frame references are rewritten to the new local ids.
 - **Named tiles are always kept.** Tiles carrying a `name` property are included in the new tileset
   even if they are not used anywhere on the map (WorkAdventure may reference them by name at runtime).
 - **Tile and tileset properties are preserved.** Per-tile properties and tileset-level properties are
   carried over onto the corresponding tiles in the new tilesets.
-- **Output is split into fixed-size "chunk" tilesets.** New tiles are packed into square tileset
-  images capped at a configurable size (default `512px`, i.e. up to 16×16 = 256 tiles per chunk).
-  Once a chunk is full a new one is started, and each rendered image is sized to the smallest square
-  grid that fits its tiles.
 - **Tileset images can optionally be compressed** with pngquant (via the `output.tileset.compress`
   option) to further shrink the output.
 

--- a/docs/algorithm.md
+++ b/docs/algorithm.md
@@ -89,16 +89,23 @@ to share a tileset instead of each getting a tiny one.
 3. Merge the pair with the highest savings, provided the union still fits the capacity.
 4. Repeat until no merge with positive savings exists.
 
-Two properties make this simple greedy work well:
+Two forces shape the result:
 
-- Because `slots(a+b) ≤ slots(a) + slots(b)`, merging never increases the padded area. With
-  `F > 0`, *any* feasible merge has positive savings — so clusters keep merging until they hit the
-  capacity ceiling. On a map whose tiles all fit in one texture, the result is a single tileset
-  shared by every layer: zero duplication, one download.
-- When the map does *not* fit in one texture, the order of merges matters — and the greedy handles
-  it: pairs sharing many tiles have much larger savings (the shared tiles are counted once instead
-  of twice), so overlapping layers merge first. Layers end up split along low-overlap boundaries,
-  which is exactly what minimizes duplication.
+- **The fixed cost `F` drives consolidation.** When merging does not grow the padded area (the
+  union fits in the slots the two clusters already occupy together), the merge saves one texture
+  essentially for free, so small and overlapping layers coalesce. On a typical map whose tiles all
+  fit in one texture, everything collapses into a single tileset shared by every layer: zero
+  duplication, one download.
+- **The power-of-2 padding vetoes wasteful merges.** Padded area *can* grow when a merge crosses a
+  power-of-2 boundary: adding a 1 024-tile cluster to an exactly-full 8 192-tile cluster would
+  jump the texture from 8 192 to 16 384 slots — 7 168 slots of pure padding just to save one file
+  — so those clusters stay separate. Merges only happen while they reduce
+  `total padded area + F × number of textures`.
+
+When the map does *not* fit in one texture, the order of merges matters — and the greedy handles
+it: pairs sharing many tiles have much larger savings (the shared tiles are counted once instead
+of twice), so overlapping layers merge first. Layers end up split along low-overlap boundaries,
+which is exactly what minimizes duplication.
 
 **Oversized layers.** If a *single layer* alone uses more tiles than the capacity, no clustering
 can help. The layer is never split into two layers (that would break scripts referencing layers by

--- a/docs/algorithm.md
+++ b/docs/algorithm.md
@@ -1,0 +1,142 @@
+# The optimization algorithm, step by step
+
+This document explains how wa-map-optimizer turns the tilesets of a Tiled map into a small set of
+optimized tileset textures, while guaranteeing that **every tile layer references tiles from a
+single tileset** — the requirement for Phaser 4's `TilemapGPULayer`.
+
+## The problem
+
+A Tiled map references tiles by GID (global tile id). Each layer is a grid of GIDs, and each GID
+points into one of the map's tilesets. Source maps typically embed huge tilesets of which only a
+fraction is used, so the optimizer extracts the used tiles and re-packs them into new textures.
+
+The naive approach — pack tiles into fixed-size textures in the order they are discovered — breaks
+GPU rendering: a layer's tiles end up scattered across whatever textures happened to be open when
+each tile was first seen. `TilemapGPULayer` needs all tiles of a layer in **one** tileset.
+
+The constraints are:
+
+- each layer must draw from exactly one tileset;
+- a tileset may be shared by several layers;
+- a tile may be duplicated into several tilesets if necessary, but as rarely as possible;
+- textures must have power-of-2 dimensions (rectangles allowed, e.g. 2048×1024), capped at a
+  configurable maximum size (default 4096×4096).
+
+## Key insight: tilesets = clusters of layers
+
+Since each layer needs exactly one tileset and tilesets can be shared, every valid solution has the
+same shape: **partition the layers into clusters, and give each cluster one tileset containing the
+union of the tiles used by its member layers.**
+
+- Two layers in the same cluster share a tileset — zero duplication between them.
+- Two layers in *different* clusters that share tiles force those tiles to be **duplicated** into
+  both tilesets.
+
+So the whole problem reduces to a single question: *which layers should be grouped together?*
+Duplication is never decided tile by tile; it falls out of the clustering. (Finding the optimal
+partition is NP-hard — it is a form of hypergraph partitioning — but a map has tens of layers, so a
+good greedy heuristic is both fast and close to optimal.)
+
+The optimizer runs in three passes.
+
+## Pass 1 — Analysis (`src/LayerAnalysis.ts`)
+
+Walk every tile layer of the map (recursing into group layers) and build, for each layer, the set
+of tiles it uses:
+
+1. **Strip flip bits.** Tiled stores horizontal/vertical/diagonal flips in bits 29–31 of the GID.
+   The tile identity is `gid & 0x1FFFFFFF`; the flip bits are saved and re-applied at the end, so a
+   tile and its flipped variants count as one tile.
+2. **Expand animation closures.** If a tile is animated, all of its animation frames (recursively)
+   are added to the layer's set. Frame ids are *tileset-local* in the Tiled format, so a tile and
+   its frames must end up in the same tileset — keeping them in the same set from the start
+   guarantees it.
+3. **Handle broken references.** A GID that belongs to no tileset is reported and later remapped to
+   the empty tile, as before.
+4. **Named tiles pseudo-layer.** Tiles carrying a `name` property must survive optimization even if
+   unused (WorkAdventure scripts can place them at runtime). Named tiles already used by some layer
+   need nothing special; the remaining ones are gathered (with their animation closures) into one
+   *pseudo-layer* that goes through clustering like any other layer, so they get packed wherever it
+   is cheapest.
+
+Output: one set of tile GIDs per layer.
+
+## Pass 2 — Clustering (`src/Clustering.ts`)
+
+This pass decides which layers share a tileset. It is a pure function, independent of any image
+processing.
+
+**Capacity.** A tileset texture is capped at `maxTextureSize` pixels (option
+`output.tileset.size`, default 4096), i.e. `(maxTextureSize / tileSize)²` tiles — 16 384 tiles for
+4096px textures with 32px tiles.
+
+**Cost of a cluster.** For a cluster using `n` distinct tiles:
+
+```
+slots(n) = smallest power of 2 ≥ n     (the padded capacity of the texture)
+cost(n)  = slots(n) + F
+```
+
+`F` is a small fixed per-tileset overhead (64 slots). It represents the real cost of one more
+texture — an extra HTTP request, an extra GPU texture bind — and is what pushes many small layers
+to share a tileset instead of each getting a tiny one.
+
+**Greedy agglomerative merging.**
+
+1. Start with one cluster per layer (layers with no tiles are skipped).
+2. For every pair of clusters, compute
+   `savings = cost(A) + cost(B) − cost(A ∪ B)`.
+3. Merge the pair with the highest savings, provided the union still fits the capacity.
+4. Repeat until no merge with positive savings exists.
+
+Two properties make this simple greedy work well:
+
+- Because `slots(a+b) ≤ slots(a) + slots(b)`, merging never increases the padded area. With
+  `F > 0`, *any* feasible merge has positive savings — so clusters keep merging until they hit the
+  capacity ceiling. On a map whose tiles all fit in one texture, the result is a single tileset
+  shared by every layer: zero duplication, one download.
+- When the map does *not* fit in one texture, the order of merges matters — and the greedy handles
+  it: pairs sharing many tiles have much larger savings (the shared tiles are counted once instead
+  of twice), so overlapping layers merge first. Layers end up split along low-overlap boundaries,
+  which is exactly what minimizes duplication.
+
+**Oversized layers.** If a *single layer* alone uses more tiles than the capacity, no clustering
+can help. The layer is never split into two layers (that would break scripts referencing layers by
+name); instead its cluster is flagged, a warning is printed, and pass 3 renders it with several
+tilesets. Such a layer is not GPU-eligible; every other layer keeps the single-tileset guarantee.
+
+**Determinism.** Ties are broken by layer order, members and clusters are sorted by layer index,
+and tiles are later laid out in GID order — the same input always produces byte-identical output,
+which keeps builds reproducible and cache-friendly.
+
+## Pass 3 — Rendering and remapping (`src/Optimizer.ts`)
+
+For each cluster, in order:
+
+1. **Order the tiles** by original GID and assign local ids `0..n-1`.
+2. **Choose the texture dimensions.** For `slots(n) = 2^e` slots, use `2^⌈e/2⌉` columns ×
+   `2^⌊e/2⌋` rows of tiles: the smallest power-of-2 rectangle holding `n` tiles, as close to square
+   as possible, width ≥ height. E.g. 300 tiles → 512 slots → 32×16 tiles → 1024×512 pixels.
+3. **Render the texture.** Each tile is extracted from its source tileset image (honoring margin
+   and spacing) and composited at `(local id mod columns, local id ÷ columns)`.
+4. **Rebuild the tileset metadata.** Tileset-level properties and per-tile properties are copied
+   onto the new tiles; animations are rewritten to the new local frame ids. `firstgid` values are
+   assigned cumulatively across the output tilesets.
+5. **Remap the layers.** Every cell of every member layer is rewritten:
+   `new GID = cluster firstgid + local id`, with the original flip bits OR-ed back on top. A tile
+   duplicated into two clusters legitimately gets a different GID in each — each layer uses its own
+   cluster's mapping.
+
+For an oversized cluster, step 1 additionally splits the tile list into capacity-sized chunks,
+keeping each animation group (a tile plus its frames) whole within a chunk — duplicating a frame
+across chunks in the rare case where two animations share frames — so animations never break.
+
+## Worked example
+
+A real 24-layer map (an airport hub) uses 2 023 distinct tiles out of 39 source tilesets:
+
+- With the default 4096px cap, all layers cluster together: **one single 2048×1024 texture**
+  (2 023 ≤ 2 048 slots), every layer GPU-eligible, zero duplicated tiles, 1.2 % padding waste.
+- With the cap forced down to 512px (256 tiles per texture), the optimizer produces 12 textures:
+  22 layers keep exactly one tileset each, and the 2 layers that individually exceed 256 tiles are
+  warned about and split across several tilesets.

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
             },
             "devDependencies": {
                 "@types/imagemin": "^8.0.1",
-                "@types/node": "^18.11.18",
+                "@types/node": "^22.20.1",
                 "@types/pngjs": "^6.0.1",
                 "@types/sharp": "^0.30.2",
                 "@typescript-eslint/eslint-plugin": "^5.47.1",
@@ -29,7 +29,8 @@
                 "lint-staged": ">=10",
                 "prettier": "^2.8.1",
                 "ts-node": "^10.9.1",
-                "typescript": "^4.9.4"
+                "typescript": "^4.9.4",
+                "vitest": "^4.1.10"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {
@@ -52,6 +53,64 @@
             "engines": {
                 "node": ">=12"
             }
+        },
+        "node_modules/@emnapi/core": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+            "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.2.2",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/core/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD",
+            "optional": true
+        },
+        "node_modules/@emnapi/runtime": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+            "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/runtime/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD",
+            "optional": true
+        },
+        "node_modules/@emnapi/wasi-threads": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+            "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/wasi-threads/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD",
+            "optional": true
         },
         "node_modules/@eslint-community/eslint-utils": {
             "version": "4.4.0",
@@ -152,10 +211,11 @@
             }
         },
         "node_modules/@jridgewell/sourcemap-codec": {
-            "version": "1.4.15",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-            "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-            "dev": true
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@jridgewell/trace-mapping": {
             "version": "0.3.9",
@@ -165,6 +225,25 @@
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.0.3",
                 "@jridgewell/sourcemap-codec": "^1.4.10"
+            }
+        },
+        "node_modules/@napi-rs/wasm-runtime": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+            "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@tybys/wasm-util": "^0.10.3"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            },
+            "peerDependencies": {
+                "@emnapi/core": "^1.7.1",
+                "@emnapi/runtime": "^1.7.1"
             }
         },
         "node_modules/@nodelib/fs.scandir": {
@@ -199,6 +278,280 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/@oxc-project/types": {
+            "version": "0.139.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+            "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/Boshen"
+            }
+        },
+        "node_modules/@rolldown/binding-android-arm64": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+            "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-darwin-arm64": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+            "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-darwin-x64": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+            "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-freebsd-x64": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+            "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+            "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm64-gnu": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+            "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm64-musl": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+            "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+            "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-s390x-gnu": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+            "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-x64-gnu": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+            "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-x64-musl": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+            "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-openharmony-arm64": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+            "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-wasm32-wasi": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+            "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+            "cpu": [
+                "wasm32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/core": "1.11.1",
+                "@emnapi/runtime": "1.11.1",
+                "@napi-rs/wasm-runtime": "^1.1.6"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-win32-arm64-msvc": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+            "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-win32-x64-msvc": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+            "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/pluginutils": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+            "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@sindresorhus/is": {
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
@@ -206,6 +559,13 @@
             "engines": {
                 "node": ">=4"
             }
+        },
+        "node_modules/@standard-schema/spec": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+            "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@tokenizer/token": {
             "version": "0.3.0",
@@ -236,6 +596,50 @@
             "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
             "dev": true
         },
+        "node_modules/@tybys/wasm-util": {
+            "version": "0.10.3",
+            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+            "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@tybys/wasm-util/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD",
+            "optional": true
+        },
+        "node_modules/@types/chai": {
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+            "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/deep-eql": "*",
+                "assertion-error": "^2.0.1"
+            }
+        },
+        "node_modules/@types/deep-eql": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+            "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/estree": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+            "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/imagemin": {
             "version": "8.0.1",
             "resolved": "https://registry.npmjs.org/@types/imagemin/-/imagemin-8.0.1.tgz",
@@ -252,10 +656,14 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "18.18.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.0.tgz",
-            "integrity": "sha512-3xA4X31gHT1F1l38ATDIL9GpRLdwVhnEFC8Uikv5ZLlXATwrCYyPq7ZWHxzxc3J/30SUiwiYT+bQe0/XvKlWbw==",
-            "dev": true
+            "version": "22.20.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+            "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~6.21.0"
+            }
         },
         "node_modules/@types/pngjs": {
             "version": "6.0.2",
@@ -469,6 +877,92 @@
                 "url": "https://opencollective.com/typescript-eslint"
             }
         },
+        "node_modules/@vitest/expect": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+            "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@standard-schema/spec": "^1.1.0",
+                "@types/chai": "^5.2.2",
+                "@vitest/spy": "4.1.10",
+                "@vitest/utils": "4.1.10",
+                "chai": "^6.2.2",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/pretty-format": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+            "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/runner": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+            "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/utils": "4.1.10",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/snapshot": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+            "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.10",
+                "@vitest/utils": "4.1.10",
+                "magic-string": "^0.30.21",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/spy": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+            "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/utils": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+            "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.10",
+                "convert-source-map": "^2.0.0",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
         "node_modules/@workadventure/tiled-map-type-guard": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/@workadventure/tiled-map-type-guard/-/tiled-map-type-guard-2.1.1.tgz",
@@ -631,6 +1125,16 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/assertion-error": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+            "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/balanced-match": {
@@ -1357,6 +1861,16 @@
                 "node": ">=4"
             }
         },
+        "node_modules/chai": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+            "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/chalk": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1494,6 +2008,13 @@
             "engines": {
                 "node": ">= 0.6"
             }
+        },
+        "node_modules/convert-source-map": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/core-util-is": {
             "version": "1.0.3",
@@ -1727,9 +2248,10 @@
             "dev": true
         },
         "node_modules/detect-libc": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
-            "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+            "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+            "license": "Apache-2.0",
             "engines": {
                 "node": ">=8"
             }
@@ -1835,6 +2357,13 @@
             "dependencies": {
                 "once": "^1.4.0"
             }
+        },
+        "node_modules/es-module-lexer": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+            "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/escape-string-regexp": {
             "version": "4.0.0",
@@ -2032,6 +2561,16 @@
                 "node": ">=4.0"
             }
         },
+        "node_modules/estree-walker": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0"
+            }
+        },
         "node_modules/esutils": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2094,6 +2633,16 @@
             "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/expect-type": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+            "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=12.0.0"
             }
         },
         "node_modules/ext-list": {
@@ -2332,6 +2881,21 @@
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
             "dev": true
+        },
+        "node_modules/fsevents": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
         },
         "node_modules/get-proxy": {
             "version": "2.1.0",
@@ -2885,6 +3449,267 @@
                 "node": ">= 0.8.0"
             }
         },
+        "node_modules/lightningcss": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+            "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+            "dev": true,
+            "license": "MPL-2.0",
+            "dependencies": {
+                "detect-libc": "^2.0.3"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            },
+            "optionalDependencies": {
+                "lightningcss-android-arm64": "1.32.0",
+                "lightningcss-darwin-arm64": "1.32.0",
+                "lightningcss-darwin-x64": "1.32.0",
+                "lightningcss-freebsd-x64": "1.32.0",
+                "lightningcss-linux-arm-gnueabihf": "1.32.0",
+                "lightningcss-linux-arm64-gnu": "1.32.0",
+                "lightningcss-linux-arm64-musl": "1.32.0",
+                "lightningcss-linux-x64-gnu": "1.32.0",
+                "lightningcss-linux-x64-musl": "1.32.0",
+                "lightningcss-win32-arm64-msvc": "1.32.0",
+                "lightningcss-win32-x64-msvc": "1.32.0"
+            }
+        },
+        "node_modules/lightningcss-android-arm64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+            "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-arm64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+            "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-x64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+            "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-freebsd-x64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+            "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm-gnueabihf": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+            "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-gnu": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+            "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-musl": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+            "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-gnu": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+            "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-musl": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+            "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-arm64-msvc": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+            "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-x64-msvc": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+            "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
         "node_modules/lilconfig": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
@@ -3166,6 +3991,16 @@
                 "node": ">=10"
             }
         },
+        "node_modules/magic-string": {
+            "version": "0.30.21",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+            "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.5"
+            }
+        },
         "node_modules/make-dir": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
@@ -3270,6 +4105,25 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
             "dev": true
+        },
+        "node_modules/nanoid": {
+            "version": "3.3.16",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "bin": {
+                "nanoid": "bin/nanoid.cjs"
+            },
+            "engines": {
+                "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+            }
         },
         "node_modules/napi-build-utils": {
             "version": "1.0.2",
@@ -3378,6 +4232,20 @@
             "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/obug": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+            "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+            "dev": true,
+            "funding": [
+                "https://github.com/sponsors/sxzz",
+                "https://opencollective.com/debug"
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.20.0"
             }
         },
         "node_modules/once": {
@@ -3607,6 +4475,13 @@
                 "node": ">=8"
             }
         },
+        "node_modules/pathe": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/peek-readable": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
@@ -3623,6 +4498,13 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
             "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="
+        },
+        "node_modules/picocolors": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/picomatch": {
             "version": "2.3.1",
@@ -3697,6 +4579,35 @@
             },
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/postcss": {
+            "version": "8.5.19",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+            "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/postcss/"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/postcss"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "nanoid": "^3.3.12",
+                "picocolors": "^1.1.1",
+                "source-map-js": "^1.2.1"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14"
             }
         },
         "node_modules/prebuild-install": {
@@ -3942,6 +4853,40 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/rolldown": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+            "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@oxc-project/types": "=0.139.0",
+                "@rolldown/pluginutils": "^1.0.0"
+            },
+            "bin": {
+                "rolldown": "bin/cli.mjs"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "optionalDependencies": {
+                "@rolldown/binding-android-arm64": "1.1.5",
+                "@rolldown/binding-darwin-arm64": "1.1.5",
+                "@rolldown/binding-darwin-x64": "1.1.5",
+                "@rolldown/binding-freebsd-x64": "1.1.5",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+                "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+                "@rolldown/binding-linux-arm64-musl": "1.1.5",
+                "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+                "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+                "@rolldown/binding-linux-x64-gnu": "1.1.5",
+                "@rolldown/binding-linux-x64-musl": "1.1.5",
+                "@rolldown/binding-openharmony-arm64": "1.1.5",
+                "@rolldown/binding-wasm32-wasi": "1.1.5",
+                "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+                "@rolldown/binding-win32-x64-msvc": "1.1.5"
+            }
+        },
         "node_modules/run-parallel": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -4082,6 +5027,13 @@
                 "node": ">=8"
             }
         },
+        "node_modules/siginfo": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+            "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/signal-exit": {
             "version": "3.0.7",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -4220,6 +5172,30 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/source-map-js": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+            "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/stackback": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+            "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/std-env": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+            "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/strict-uri-encode": {
             "version": "1.1.0",
@@ -4504,6 +5480,81 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/tinybench": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+            "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tinyexec": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+            "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tinyglobby": {
+            "version": "0.2.17",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+            "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.4"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/SuperchupuDev"
+            }
+        },
+        "node_modules/tinyglobby/node_modules/fdir": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "peerDependencies": {
+                "picomatch": "^3 || ^4"
+            },
+            "peerDependenciesMeta": {
+                "picomatch": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/tinyglobby/node_modules/picomatch": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/tinyrainbow": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+            "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
         "node_modules/to-buffer": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
@@ -4676,6 +5727,13 @@
                 "through": "^2.3.8"
             }
         },
+        "node_modules/undici-types": {
+            "version": "6.21.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/uri-js": {
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -4724,6 +5782,232 @@
             "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
             "dev": true
         },
+        "node_modules/vitest": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+            "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/expect": "4.1.10",
+                "@vitest/mocker": "4.1.10",
+                "@vitest/pretty-format": "4.1.10",
+                "@vitest/runner": "4.1.10",
+                "@vitest/snapshot": "4.1.10",
+                "@vitest/spy": "4.1.10",
+                "@vitest/utils": "4.1.10",
+                "es-module-lexer": "^2.0.0",
+                "expect-type": "^1.3.0",
+                "magic-string": "^0.30.21",
+                "obug": "^2.1.1",
+                "pathe": "^2.0.3",
+                "picomatch": "^4.0.3",
+                "std-env": "^4.0.0-rc.1",
+                "tinybench": "^2.9.0",
+                "tinyexec": "^1.0.2",
+                "tinyglobby": "^0.2.15",
+                "tinyrainbow": "^3.1.0",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+                "why-is-node-running": "^2.3.0"
+            },
+            "bin": {
+                "vitest": "vitest.mjs"
+            },
+            "engines": {
+                "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@edge-runtime/vm": "*",
+                "@opentelemetry/api": "^1.9.0",
+                "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+                "@vitest/browser-playwright": "4.1.10",
+                "@vitest/browser-preview": "4.1.10",
+                "@vitest/browser-webdriverio": "4.1.10",
+                "@vitest/coverage-istanbul": "4.1.10",
+                "@vitest/coverage-v8": "4.1.10",
+                "@vitest/ui": "4.1.10",
+                "happy-dom": "*",
+                "jsdom": "*",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@opentelemetry/api": {
+                    "optional": true
+                },
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitest/browser-playwright": {
+                    "optional": true
+                },
+                "@vitest/browser-preview": {
+                    "optional": true
+                },
+                "@vitest/browser-webdriverio": {
+                    "optional": true
+                },
+                "@vitest/coverage-istanbul": {
+                    "optional": true
+                },
+                "@vitest/coverage-v8": {
+                    "optional": true
+                },
+                "@vitest/ui": {
+                    "optional": true
+                },
+                "happy-dom": {
+                    "optional": true
+                },
+                "jsdom": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": false
+                }
+            }
+        },
+        "node_modules/vitest/node_modules/@vitest/mocker": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+            "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/spy": "4.1.10",
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.21"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "msw": "^2.4.9",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "msw": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vitest/node_modules/picomatch": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/vitest/node_modules/vite": {
+            "version": "8.1.4",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
+            "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "lightningcss": "^1.32.0",
+                "picomatch": "^4.0.5",
+                "postcss": "^8.5.16",
+                "rolldown": "~1.1.4",
+                "tinyglobby": "^0.2.17"
+            },
+            "bin": {
+                "vite": "bin/vite.js"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "funding": {
+                "url": "https://github.com/vitejs/vite?sponsor=1"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.3"
+            },
+            "peerDependencies": {
+                "@types/node": "^20.19.0 || >=22.12.0",
+                "@vitejs/devtools": "^0.3.0",
+                "esbuild": "^0.27.0 || ^0.28.0",
+                "jiti": ">=1.21.0",
+                "less": "^4.0.0",
+                "sass": "^1.70.0",
+                "sass-embedded": "^1.70.0",
+                "stylus": ">=0.54.8",
+                "sugarss": "^5.0.0",
+                "terser": "^5.16.0",
+                "tsx": "^4.8.1",
+                "yaml": "^2.4.2"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitejs/devtools": {
+                    "optional": true
+                },
+                "esbuild": {
+                    "optional": true
+                },
+                "jiti": {
+                    "optional": true
+                },
+                "less": {
+                    "optional": true
+                },
+                "sass": {
+                    "optional": true
+                },
+                "sass-embedded": {
+                    "optional": true
+                },
+                "stylus": {
+                    "optional": true
+                },
+                "sugarss": {
+                    "optional": true
+                },
+                "terser": {
+                    "optional": true
+                },
+                "tsx": {
+                    "optional": true
+                },
+                "yaml": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vitest/node_modules/yaml": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+            "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+            "dev": true,
+            "license": "ISC",
+            "optional": true,
+            "peer": true,
+            "bin": {
+                "yaml": "bin.mjs"
+            },
+            "engines": {
+                "node": ">= 14.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/eemeli"
+            }
+        },
         "node_modules/which": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4736,6 +6020,23 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/why-is-node-running": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+            "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "siginfo": "^2.0.0",
+                "stackback": "0.0.2"
+            },
+            "bin": {
+                "why-is-node-running": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
         "typecheck": "tsc --noEmit",
         "lint": "eslint --ext .js,.ts .",
         "format": "prettier --ignore-path .gitignore --write \"**/*.+(js|ts|json)\"",
-        "dev": "node --loader ts-node/esm --experimental-specifier-resolution=node ./example/index.ts"
+        "dev": "node --loader ts-node/esm --experimental-specifier-resolution=node ./example/index.ts",
+        "test": "vitest run"
     },
     "dependencies": {
         "@workadventure/tiled-map-type-guard": "^2.1.1",
@@ -32,7 +33,7 @@
     },
     "devDependencies": {
         "@types/imagemin": "^8.0.1",
-        "@types/node": "^18.11.18",
+        "@types/node": "^22.20.1",
         "@types/pngjs": "^6.0.1",
         "@types/sharp": "^0.30.2",
         "@typescript-eslint/eslint-plugin": "^5.47.1",
@@ -43,7 +44,8 @@
         "lint-staged": ">=10",
         "prettier": "^2.8.1",
         "ts-node": "^10.9.1",
-        "typescript": "^4.9.4"
+        "typescript": "^4.9.4",
+        "vitest": "^4.1.10"
     },
     "lint-staged": {
         "*.{js,ts}": [

--- a/src/Clustering.ts
+++ b/src/Clustering.ts
@@ -59,8 +59,10 @@ function unionSize(a: ReadonlySet<number>, b: ReadonlySet<number>): number {
  *
  * Cost of a cluster = power-of-2 padded slot count + `fixedCost` (a per-tileset overhead standing
  * for the extra HTTP request / texture bind, which pushes small disjoint layers to share a
- * tileset). Since padding never grows when merging, clusters merge until the capacity is reached,
- * high-overlap pairs first — which is what minimizes tile duplication across tilesets.
+ * tileset). A merge happens only while it lowers the total cost: high-overlap pairs merge first
+ * (their shared tiles are counted once instead of twice), and a merge that would cross a
+ * power-of-2 boundary — doubling a texture mostly to hold padding — is declined. Merging stops at
+ * the capacity or when no pair pays off, whichever comes first.
  *
  * Layers with no tiles are skipped, layers bigger than `capacity` get their own cluster flagged
  * `oversized`. Output is deterministic: clusters and their members are ordered by layer index.

--- a/src/Clustering.ts
+++ b/src/Clustering.ts
@@ -1,0 +1,135 @@
+/**
+ * Pass 2 of the optimization: group layers into clusters, each cluster becoming one output tileset
+ * holding the union of the tiles used by its member layers.
+ *
+ * Phaser 4's TilemapGPULayer can only render a layer whose tiles all come from a single tileset, so
+ * every output tileset corresponds 1:1 with a cluster of layers. Tiles used by layers living in
+ * different clusters are duplicated into each cluster's tileset; the clustering below minimizes this.
+ */
+
+export type ClusterInput = {
+    /** Position of the layer in the analysis pass output, used for deterministic ordering */
+    index: number;
+    /** Human-readable name, used in logs */
+    name: string;
+    /** Unflipped tile GIDs used by the layer (animation closures included) */
+    tiles: ReadonlySet<number>;
+};
+
+export type Cluster = {
+    members: ClusterInput[];
+    tiles: Set<number>;
+    /**
+     * True when a single layer uses more tiles than the capacity of one tileset. Such a cluster is
+     * rendered as several tilesets and its layers are not eligible for GPU rendering.
+     */
+    oversized: boolean;
+};
+
+/**
+ * Smallest power of 2 greater than or equal to the given tile count: the number of slots of the
+ * smallest rectangular power-of-2 texture able to hold that many tiles.
+ */
+export function slotsFor(tileCount: number): number {
+    let slots = 1;
+    while (slots < tileCount) {
+        slots *= 2;
+    }
+    return slots;
+}
+
+function cost(tileCount: number, fixedCost: number): number {
+    return slotsFor(tileCount) + fixedCost;
+}
+
+function unionSize(a: ReadonlySet<number>, b: ReadonlySet<number>): number {
+    const [small, large] = a.size < b.size ? [a, b] : [b, a];
+    let extra = 0;
+    for (const tile of small) {
+        if (!large.has(tile)) {
+            extra++;
+        }
+    }
+    return large.size + extra;
+}
+
+/**
+ * Greedy agglomerative clustering: start with one cluster per layer and repeatedly merge the pair
+ * of clusters saving the most texture slots, as long as the merged cluster fits in `capacity`.
+ *
+ * Cost of a cluster = power-of-2 padded slot count + `fixedCost` (a per-tileset overhead standing
+ * for the extra HTTP request / texture bind, which pushes small disjoint layers to share a
+ * tileset). Since padding never grows when merging, clusters merge until the capacity is reached,
+ * high-overlap pairs first — which is what minimizes tile duplication across tilesets.
+ *
+ * Layers with no tiles are skipped, layers bigger than `capacity` get their own cluster flagged
+ * `oversized`. Output is deterministic: clusters and their members are ordered by layer index.
+ */
+export function clusterLayers(inputs: ClusterInput[], capacity: number, fixedCost = 64): Cluster[] {
+    const clusters: Cluster[] = [];
+
+    for (const input of inputs) {
+        if (input.tiles.size === 0) {
+            continue;
+        }
+
+        clusters.push({
+            members: [input],
+            tiles: new Set(input.tiles),
+            oversized: input.tiles.size > capacity,
+        });
+    }
+
+    for (;;) {
+        let best: { i: number; j: number; savings: number } | undefined;
+
+        for (let i = 0; i < clusters.length; i++) {
+            if (clusters[i].oversized) {
+                continue;
+            }
+
+            for (let j = i + 1; j < clusters.length; j++) {
+                if (clusters[j].oversized) {
+                    continue;
+                }
+
+                const merged = unionSize(clusters[i].tiles, clusters[j].tiles);
+
+                if (merged > capacity) {
+                    continue;
+                }
+
+                const savings =
+                    cost(clusters[i].tiles.size, fixedCost) +
+                    cost(clusters[j].tiles.size, fixedCost) -
+                    cost(merged, fixedCost);
+
+                // Strict comparison: on equal savings the first (lowest-index) pair wins, keeping the
+                // result deterministic.
+                if (savings > 0 && (!best || savings > best.savings)) {
+                    best = { i, j, savings };
+                }
+            }
+        }
+
+        if (!best) {
+            break;
+        }
+
+        const absorbed = clusters.splice(best.j, 1)[0];
+        const target = clusters[best.i];
+        target.members.push(...absorbed.members);
+
+        for (const tile of absorbed.tiles) {
+            target.tiles.add(tile);
+        }
+    }
+
+    for (const cluster of clusters) {
+        cluster.members.sort((a, b) => a.index - b.index);
+    }
+
+    clusters.sort((a, b) => a.members[0].index - b.members[0].index);
+
+    return clusters;
+}

--- a/src/LayerAnalysis.ts
+++ b/src/LayerAnalysis.ts
@@ -1,0 +1,190 @@
+import { ITiledMapEmbeddedTileset, ITiledMapLayer, ITiledMapTile } from "@workadventure/tiled-map-type-guard";
+
+/** Bits 0-28 of a Tiled GID: the actual tile id */
+export const GID_MASK = 0x1fffffff;
+/** Bits 29-31 of a Tiled GID: diagonal / vertical / horizontal flip flags */
+export const FLIP_MASK = 0xe0000000;
+
+export function stripFlipBits(rawGid: number): { gid: number; flipBits: number } {
+    return {
+        gid: (rawGid & GID_MASK) >>> 0,
+        flipBits: (rawGid & FLIP_MASK) >>> 0,
+    };
+}
+
+export function applyFlipBits(gid: number, flipBits: number): number {
+    return (gid | flipBits) >>> 0;
+}
+
+export type LayerTileSet = {
+    /** Undefined for the pseudo-layer holding named tiles that no layer uses */
+    layer?: ITiledMapLayer;
+    name: string;
+    /** Unflipped GIDs used by the layer, animation closures included */
+    tiles: Set<number>;
+};
+
+/** Resolves GIDs to their source tileset and per-tile data */
+export class TilesetIndex {
+    private readonly entries: { firstgid: number; lastgid: number; tileset: ITiledMapEmbeddedTileset }[] = [];
+
+    constructor(tilesets: ITiledMapEmbeddedTileset[]) {
+        for (const tileset of tilesets) {
+            if (tileset.firstgid === undefined) {
+                throw new Error(`firstgid property is undefined on ${tileset.name} tileset`);
+            }
+
+            if (tileset.tilecount === undefined) {
+                throw new Error(`tilecount property is undefined on ${tileset.name} tileset`);
+            }
+
+            this.entries.push({
+                firstgid: tileset.firstgid,
+                lastgid: tileset.firstgid + tileset.tilecount - 1,
+                tileset: tileset,
+            });
+        }
+    }
+
+    public getTileset(gid: number): ITiledMapEmbeddedTileset | undefined {
+        return this.entries.find((entry) => gid >= entry.firstgid && gid <= entry.lastgid)?.tileset;
+    }
+
+    public getTileData(gid: number): ITiledMapTile | undefined {
+        const entry = this.entries.find((entry) => gid >= entry.firstgid && gid <= entry.lastgid);
+        return entry?.tileset.tiles?.find((tile) => tile.id === gid - entry.firstgid);
+    }
+}
+
+/**
+ * Adds the given tile and its animation closure (every animation frame, recursively) to `into`.
+ * Frame ids are tileset-local in Tiled, so a tile and its frames must always land in the same
+ * output tileset: keeping them in the same set guarantees it.
+ */
+export function expandTileClosure(gid: number, tilesetIndex: TilesetIndex, into: Set<number>): void {
+    if (into.has(gid)) {
+        return;
+    }
+
+    into.add(gid);
+
+    const tileset = tilesetIndex.getTileset(gid);
+    const firstgid = tileset?.firstgid;
+
+    if (firstgid === undefined) {
+        return;
+    }
+
+    const tileData = tilesetIndex.getTileData(gid);
+
+    if (!tileData?.animation) {
+        return;
+    }
+
+    for (const frame of tileData.animation) {
+        expandTileClosure(firstgid + frame.tileid, tilesetIndex, into);
+    }
+}
+
+/**
+ * Returns the tile group that must stay within a single tileset image: the tile itself plus its
+ * animation closure. Used when an oversized layer has to be split across several tilesets.
+ */
+export function animationGroup(gid: number, tilesetIndex: TilesetIndex): number[] {
+    const group = new Set<number>();
+    expandTileClosure(gid, tilesetIndex, group);
+    return [...group].sort((a, b) => a - b);
+}
+
+/**
+ * Pass 1: collects, for every tile layer of the map (recursing into groups), the set of unflipped
+ * GIDs it uses, expanded with animation closures. GIDs pointing to no source tileset are reported
+ * in `unknownGids` and excluded from the sets (they will be remapped to 0, as before).
+ */
+export function collectLayerTileSets(
+    layers: ITiledMapLayer[],
+    tilesetIndex: TilesetIndex
+): { layerTileSets: LayerTileSet[]; unknownGids: Set<number> } {
+    const layerTileSets: LayerTileSet[] = [];
+    const unknownGids = new Set<number>();
+
+    const walk = (walkedLayers: ITiledMapLayer[]) => {
+        for (const layer of walkedLayers) {
+            if (layer.type === "group") {
+                if (layer.layers) {
+                    walk(layer.layers);
+                }
+                continue;
+            }
+
+            if (layer.type !== "tilelayer" || !layer.data || typeof layer.data === "string") {
+                continue;
+            }
+
+            const tiles = new Set<number>();
+
+            for (const rawGid of layer.data) {
+                if (rawGid === 0) {
+                    continue;
+                }
+
+                const { gid } = stripFlipBits(Number(rawGid));
+
+                if (tiles.has(gid) || unknownGids.has(gid)) {
+                    continue;
+                }
+
+                if (!tilesetIndex.getTileset(gid)) {
+                    unknownGids.add(gid);
+                    continue;
+                }
+
+                expandTileClosure(gid, tilesetIndex, tiles);
+            }
+
+            layerTileSets.push({
+                layer: layer,
+                name: layer.name ?? "unnamed layer",
+                tiles: tiles,
+            });
+        }
+    };
+
+    walk(layers);
+
+    return { layerTileSets, unknownGids };
+}
+
+/**
+ * Named tiles (tiles carrying a "name" property) must always be present in the output because
+ * WorkAdventure scripts can reference them at runtime. Named tiles already used by a layer need
+ * nothing special; this returns the remaining ones (closures included) so they can be packed as a
+ * pseudo-layer participating in the clustering.
+ */
+export function collectUnusedNamedTiles(
+    tilesets: ITiledMapEmbeddedTileset[],
+    tilesetIndex: TilesetIndex,
+    usedTiles: ReadonlySet<number>
+): Set<number> {
+    const namedTiles = new Set<number>();
+
+    for (const tileset of tilesets) {
+        if (!tileset.tiles || tileset.firstgid === undefined) {
+            continue;
+        }
+
+        for (const tile of tileset.tiles) {
+            const gid = tileset.firstgid + tile.id;
+
+            if (usedTiles.has(gid) || namedTiles.has(gid)) {
+                continue;
+            }
+
+            if (tile.properties?.find((property) => property.name === "name")) {
+                expandTileClosure(gid, tilesetIndex, namedTiles);
+            }
+        }
+    }
+
+    return namedTiles;
+}

--- a/src/Optimizer.ts
+++ b/src/Optimizer.ts
@@ -163,7 +163,9 @@ export class Optimizer {
                     );
                 }
 
-                firstgid += gids.length;
+                // Advance by the full image-grid capacity so the reserved GID range matches the
+                // image dimensions Phaser reads. renderedTileCount still counts real tiles.
+                firstgid += slotsFor(gids.length);
                 renderedTileCount += gids.length;
             }
 
@@ -174,6 +176,8 @@ export class Optimizer {
                 }
             }
         }
+
+        this.assertNoOverlappingGidRanges(newTilesets);
 
         this.remapLayers(this.optimizedMap.layers, layerMappings);
         this.optimizedMap.tilesets = newTilesets;
@@ -298,7 +302,11 @@ export class Optimizer {
             name: `Chunk ${tilesetNumber}`,
             properties: [],
             spacing: 0,
-            tilecount: gids.length,
+            // Reserve the full image-grid capacity as GIDs (columns*rows === slots), not just the
+            // used tile count. Phaser derives a tileset's tile count from the image dimensions and
+            // ignores this value, so a smaller tilecount would make consecutive tilesets' GID
+            // ranges overlap and silently drop tiles on classic TilemapLayer rendering.
+            tilecount: columns * rows,
             tileheight: this.tileSize,
             tilewidth: this.tileSize,
             tiles: tiles,
@@ -398,6 +406,35 @@ export class Optimizer {
                 height: this.tileSize,
             })
             .toBuffer();
+    }
+
+    /**
+     * Phaser derives a tileset's tile count from its image dimensions and ignores the JSON
+     * `tilecount`, so a tileset effectively owns `[firstgid, firstgid + columns*rows)`. If two of
+     * those ranges intersect, the last one written wins the overlap and tiles belonging to the
+     * other tileset silently render transparent. The emit loop reserves the full image-grid
+     * capacity per tileset precisely to avoid this; assert the invariant so any regression fails
+     * loudly instead of dropping furniture.
+     */
+    private assertNoOverlappingGidRanges(tilesets: ITiledMapEmbeddedTileset[]): void {
+        const ranges = tilesets
+            .map((tileset) => {
+                const columns = tileset.columns ?? 0;
+                const rows = (tileset.imageheight ?? 0) / this.tileSize;
+                const start = tileset.firstgid ?? 0;
+                return { name: tileset.name, start, end: start + columns * rows };
+            })
+            .sort((a, b) => a.start - b.start);
+
+        for (let i = 1; i < ranges.length; i++) {
+            const prev = ranges[i - 1];
+            const curr = ranges[i];
+            if (curr.start < prev.end) {
+                throw new Error(
+                    `Overlapping tileset GID ranges: "${prev.name}" [${prev.start}, ${prev.end}) intersects "${curr.name}" [${curr.start}, ${curr.end})`
+                );
+            }
+        }
     }
 
     private remapLayers(layers: ITiledMapLayer[], layerMappings: Map<ITiledMapLayer, Map<number, number>>): void {

--- a/src/Optimizer.ts
+++ b/src/Optimizer.ts
@@ -6,23 +6,38 @@ import {
 } from "@workadventure/tiled-map-type-guard";
 import { PNG } from "pngjs";
 import sharp, { Sharp } from "sharp";
+import { Cluster, clusterLayers, slotsFor } from "./Clustering.js";
+import {
+    animationGroup,
+    applyFlipBits,
+    collectLayerTileSets,
+    collectUnusedNamedTiles,
+    stripFlipBits,
+    TilesetIndex,
+} from "./LayerAnalysis.js";
 import { LogLevel, OptimizeBufferOptions } from "./guards/libGuards.js";
 
 sharp.cache(false);
 
+/**
+ * Per-tileset overhead used by the clustering cost function, in tile slots. It stands for the cost
+ * of one more HTTP request / GPU texture, and pushes small disjoint layers to share a tileset.
+ */
+const TILESET_FIXED_COST = 64;
+
+/**
+ * The optimizer guarantees that each tile layer references tiles from a single output tileset
+ * (Phaser 4 TilemapGPULayer requirement), by clustering layers and rendering one tileset per
+ * cluster. It works in three passes:
+ * 1. Analysis: collect the set of tiles used by each layer (animation closures included).
+ * 2. Clustering: group layers so that each group's tile union fits in one power-of-2 texture.
+ * 3. Rendering: draw one tileset image per cluster and remap every layer's tile ids.
+ */
 export class Optimizer {
     private optimizedMap: ITiledMap;
-    /**
-     * A map mapping the old tile id to the new tile id (global) and to the new tile id in the current tileset
-     * @private
-     */
-    private optimizedTiles: Map<number, { global: number; local: number }>;
-    private optimizedTilesets: ITiledMapEmbeddedTileset[];
-    private currentTilesetOptimization: ITiledMapEmbeddedTileset;
-    private currentExtractedTiles: Promise<Buffer>[];
     private tileSize: number;
-    private outputSize: number;
-    private tilesetMaxTileCount: number;
+    private maxTextureSize: number;
+    private tilesetCapacity: number;
     private tilesetPrefix: string;
     private tilesetSuffix?: string;
     private logLevel: LogLevel;
@@ -34,18 +49,26 @@ export class Optimizer {
         private readonly outputPath: string
     ) {
         this.optimizedMap = map;
-        this.optimizedTiles = new Map<number, { global: number; local: number }>();
-        this.optimizedTilesets = [];
         this.tileSize = options?.tile?.size ?? 32;
-        this.outputSize = options?.output?.tileset?.size ? options?.output?.tileset?.size : 512;
-        const maxColumns = this.outputSize / 32;
-        this.tilesetMaxTileCount = maxColumns * maxColumns;
+        this.maxTextureSize = options?.output?.tileset?.size ?? 4096;
         this.tilesetPrefix = options?.output?.tileset?.prefix ?? "chunk";
         this.tilesetSuffix = options?.output?.tileset?.suffix;
         this.logLevel = options?.logs ?? LogLevel.NORMAL;
 
-        this.currentTilesetOptimization = this.generateNextTileset();
-        this.currentExtractedTiles = [];
+        if (this.maxTextureSize < this.tileSize) {
+            throw new Error(
+                `Max tileset size (${this.maxTextureSize}) cannot be smaller than the tile size (${this.tileSize})`
+            );
+        }
+
+        const maxColumns = Math.floor(this.maxTextureSize / this.tileSize);
+        this.tilesetCapacity = maxColumns * maxColumns;
+
+        if (this.logLevel && (this.tileSize & (this.tileSize - 1)) !== 0) {
+            console.warn(
+                `Tile size ${this.tileSize} is not a power of 2: output tileset images will not have power-of-2 dimensions`
+            );
+        }
 
         for (const tileset of [...tilesetsBuffers.keys()]) {
             if (tileset.tileheight !== this.tileSize || tileset.tilewidth !== this.tileSize) {
@@ -59,383 +82,262 @@ export class Optimizer {
             console.log("Start tiles optimization...");
         }
 
-        await this.optimizeLayers(this.optimizedMap.layers);
+        const sourceTilesets = [...this.tilesetsBuffers.keys()];
+        const tilesetIndex = new TilesetIndex(sourceTilesets);
 
-        await this.optimizeNamedTiles();
-
-        if (this.currentExtractedTiles.length > 0) {
-            await this.currentTilesetRendering();
-        }
-
-        this.optimizedMap.tilesets = [];
-
-        for (const currentTileset of this.optimizedTilesets) {
-            this.optimizedMap.tilesets.push(currentTileset);
-        }
+        // Pass 1: analysis
+        const { layerTileSets, unknownGids } = collectLayerTileSets(this.optimizedMap.layers, tilesetIndex);
 
         if (this.logLevel) {
-            console.log("Tiles optimization has been done");
+            for (const gid of unknownGids) {
+                console.error(`${gid} undefined! Corrupted layers or undefined in tilesets`);
+                console.error("This tile has been replaced by an empty tile");
+            }
+        }
+
+        const usedTiles = new Set<number>();
+        for (const layerTileSet of layerTileSets) {
+            for (const gid of layerTileSet.tiles) {
+                usedTiles.add(gid);
+            }
+        }
+
+        const namedTiles = collectUnusedNamedTiles(sourceTilesets, tilesetIndex, usedTiles);
+        if (namedTiles.size > 0) {
+            layerTileSets.push({ name: "<named tiles>", tiles: namedTiles });
+            for (const gid of namedTiles) {
+                usedTiles.add(gid);
+            }
+        }
+
+        // Pass 2: clustering
+        const clusters = clusterLayers(
+            layerTileSets.map((layerTileSet, index) => ({
+                index: index,
+                name: layerTileSet.name,
+                tiles: layerTileSet.tiles,
+            })),
+            this.tilesetCapacity,
+            TILESET_FIXED_COST
+        );
+
+        for (const cluster of clusters) {
+            if (cluster.oversized && this.logLevel) {
+                console.warn(
+                    `Layer "${cluster.members[0].name}" uses ${cluster.tiles.size} tiles, more than the ${this.tilesetCapacity} fitting in a single ${this.maxTextureSize}x${this.maxTextureSize} tileset.`
+                );
+                console.warn(
+                    "It will be split across several tilesets and will NOT be eligible for GPU rendering. Consider raising output.tileset.size or simplifying the layer."
+                );
+            }
+        }
+
+        // Pass 3: rendering & remapping
+        const layerMappings = new Map<ITiledMapLayer, Map<number, number>>();
+        const newTilesets: ITiledMapEmbeddedTileset[] = [];
+        let firstgid = 1;
+        let renderedTileCount = 0;
+
+        for (const cluster of clusters) {
+            const chunks = this.splitIntoChunks(cluster, tilesetIndex);
+            const clusterMapping = new Map<number, number>();
+
+            for (const gids of chunks) {
+                const localIds = new Map<number, number>();
+
+                for (const [localId, gid] of gids.entries()) {
+                    localIds.set(gid, localId);
+                    clusterMapping.set(gid, firstgid + localId);
+                }
+
+                const tileset = this.buildTilesetData(gids, localIds, firstgid, newTilesets.length + 1, tilesetIndex);
+                await this.renderTileset(gids, tileset, tilesetIndex);
+                newTilesets.push(tileset);
+
+                if (this.logLevel) {
+                    const layerNames = cluster.members.map((member) => member.name).join(", ");
+                    console.log(
+                        `${tileset.name}: ${tileset.imagewidth ?? 0}x${tileset.imageheight ?? 0}px, ${
+                            gids.length
+                        } tiles — layers: ${layerNames}`
+                    );
+                }
+
+                firstgid += gids.length;
+                renderedTileCount += gids.length;
+            }
+
+            for (const member of cluster.members) {
+                const layer = layerTileSets[member.index].layer;
+                if (layer) {
+                    layerMappings.set(layer, clusterMapping);
+                }
+            }
+        }
+
+        this.remapLayers(this.optimizedMap.layers, layerMappings);
+        this.optimizedMap.tilesets = newTilesets;
+
+        if (this.logLevel) {
+            const duplicated = renderedTileCount - usedTiles.size;
+            console.log(
+                `Tiles optimization has been done: ${newTilesets.length} tileset(s), ${usedTiles.size} unique tiles, ${duplicated} duplicated`
+            );
         }
 
         return this.optimizedMap;
     }
 
-    private async optimizeLayers(layers: ITiledMapLayer[]): Promise<void> {
-        for (let i = 0; i < layers.length; i++) {
-            const layer = layers[i];
+    /**
+     * A regular cluster fits in a single tileset. An oversized cluster (a single layer using more
+     * tiles than the capacity) is split into several tilesets; animation groups are kept whole
+     * within a chunk (frame ids are tileset-local), duplicating frames across chunks if needed.
+     */
+    private splitIntoChunks(cluster: Cluster, tilesetIndex: TilesetIndex): number[][] {
+        const sorted = [...cluster.tiles].sort((a, b) => a - b);
 
-            if (layer.type === "group") {
-                if (!layer.layers) {
-                    continue;
-                }
+        if (!cluster.oversized) {
+            return [sorted];
+        }
 
-                await this.optimizeLayers(layer.layers);
+        const chunks: number[][] = [];
+        let current: number[] = [];
+        let currentSet = new Set<number>();
+        const placed = new Set<number>();
+
+        for (const gid of sorted) {
+            // Closures are transitively closed, so a tile placed as part of a previous group
+            // already sits in the same chunk as its own animation frames.
+            if (placed.has(gid)) {
                 continue;
             }
 
-            if (layer.type !== "tilelayer") {
-                continue;
+            const group = animationGroup(gid, tilesetIndex);
+            let toAdd = group.filter((groupGid) => !currentSet.has(groupGid));
+
+            if (current.length > 0 && current.length + toAdd.length > this.tilesetCapacity) {
+                chunks.push(current);
+                current = [];
+                currentSet = new Set();
+                toAdd = group;
             }
 
-            if (!layer.data) {
-                continue;
-            }
-
-            for (let y = 0; y < layer.data.length; y++) {
-                if (typeof layer.data === "string") {
-                    continue;
-                }
-
-                const tileId = layer.data[y];
-
-                if (tileId === 0) {
-                    continue;
-                }
-
-                await this.checkCurrentTileset();
-
-                const newTileId = await this.optimizeNewTile(Number(tileId));
-
-                layer.data[y] = newTileId;
+            for (const groupGid of toAdd) {
+                current.push(groupGid);
+                currentSet.add(groupGid);
+                placed.add(groupGid);
             }
         }
+
+        if (current.length > 0) {
+            chunks.push(current);
+        }
+
+        return chunks;
     }
 
-    private async optimizeNamedTiles(): Promise<void> {
-        for (const tileset of this.tilesetsBuffers.keys()) {
-            if (!tileset.tiles) {
-                continue;
+    private buildTilesetData(
+        gids: number[],
+        localIds: Map<number, number>,
+        firstgid: number,
+        tilesetNumber: number,
+        tilesetIndex: TilesetIndex
+    ): ITiledMapEmbeddedTileset {
+        // Smallest rectangular power-of-2 texture holding the tiles, as close to square as
+        // possible, width >= height (e.g. 300 tiles -> 512 slots -> 32x16 tiles -> 1024x512px).
+        const slots = slotsFor(gids.length);
+        const exponent = Math.log2(slots);
+        const columns = Math.pow(2, Math.ceil(exponent / 2));
+        const rows = slots / columns;
+
+        const tiles: ITiledMapTile[] = [];
+
+        for (const [localId, gid] of gids.entries()) {
+            const sourceTileset = tilesetIndex.getTileset(gid);
+
+            if (!sourceTileset || sourceTileset.firstgid === undefined) {
+                throw new Error(`No source tileset found for tile ${gid}`);
             }
 
-            if (!tileset.firstgid) {
-                throw new Error(`firstgid property is undefined on ${tileset.name} tileset`);
+            const tileData = tilesetIndex.getTileData(gid);
+            const properties = [...(sourceTileset.properties ?? []), ...(tileData?.properties ?? [])];
+            const newTile: ITiledMapTile = { id: localId };
+
+            if (properties.length > 0) {
+                newTile.properties = properties;
             }
 
-            for (const tile of tileset.tiles) {
-                const tileId = tileset.firstgid + tile.id;
+            if (tileData?.animation) {
+                const sourceFirstgid = sourceTileset.firstgid;
+                newTile.animation = tileData.animation.map((frame) => {
+                    const frameLocalId = localIds.get(sourceFirstgid + frame.tileid);
 
-                if (this.optimizedTiles.has(tileId)) {
-                    continue;
-                }
+                    if (frameLocalId === undefined) {
+                        throw new Error(`Undefined tile in animation for ${sourceFirstgid + frame.tileid}`);
+                    }
 
-                if (!tile.properties) {
-                    continue;
-                }
+                    return {
+                        duration: frame.duration,
+                        tileid: frameLocalId,
+                    };
+                });
+            }
 
-                if (tile.properties.find((property) => property.name === "name")) {
-                    await this.optimizeNewTile(tileId);
-                }
+            if (newTile.properties || newTile.animation) {
+                tiles.push(newTile);
             }
         }
-    }
 
-    private generateNextTileset(): ITiledMapEmbeddedTileset {
-        if (this.logLevel === LogLevel.VERBOSE) {
-            console.log("Generate a new tileset data");
-        }
-
-        const tilesetCount = this.optimizedTilesets.length + 1;
         return {
-            columns: 1,
-            firstgid: this.optimizedTiles.size + 1,
-            image: `${this.tilesetPrefix}-${tilesetCount}${this.tilesetSuffix ? "-" + this.tilesetSuffix : ""}.png`,
-            imageheight: 0,
-            imagewidth: 0,
+            columns: columns,
+            firstgid: firstgid,
+            image: `${this.tilesetPrefix}-${tilesetNumber}${this.tilesetSuffix ? "-" + this.tilesetSuffix : ""}.png`,
+            imageheight: rows * this.tileSize,
+            imagewidth: columns * this.tileSize,
             margin: 0,
-            name: `Chunk ${tilesetCount}`,
+            name: `Chunk ${tilesetNumber}`,
             properties: [],
             spacing: 0,
-            tilecount: 0,
+            tilecount: gids.length,
             tileheight: this.tileSize,
             tilewidth: this.tileSize,
-            tiles: [],
+            tiles: tiles,
         };
     }
 
-    private async generateNewTilesetBuffer(size: number): Promise<Buffer> {
-        const newFile = new PNG({
-            width: size,
-            height: size,
-        });
-
-        return await newFile.pack().pipe(sharp()).toBuffer();
-    }
-
-    private async optimizeNewTile(tileId: number): Promise<number> {
+    private async renderTileset(
+        gids: number[],
+        tileset: ITiledMapEmbeddedTileset,
+        tilesetIndex: TilesetIndex
+    ): Promise<void> {
         if (this.logLevel === LogLevel.VERBOSE) {
-            //console.log(`${tileId} tile is optimizing...`);
+            console.log(`Rendering of ${tileset.name} tileset...`);
         }
 
-        let minBitId;
-
-        // 3758096384 = 29 & 30 & 31
-        // 3221225472 = 30 & 31
-        // 2684354560 = 29 & 31
-        // 2147483648 = 31
-        // 1610612736 = 29 & 30
-        // 1073741824 = 30
-        // 536870912 = 29
-
-        const bit29 = Math.pow(2, 29);
-        const bit30 = Math.pow(2, 30);
-        const bit31 = Math.pow(2, 31);
-        const bit32 = Math.pow(2, 32);
-
-        if (tileId < bit29) {
-            minBitId = 0;
-        } else if (tileId < bit30) {
-            minBitId = bit29;
-        } else if (tileId < bit29 + bit30) {
-            minBitId = bit30;
-        } else if (tileId < bit31) {
-            minBitId = bit29 + bit30;
-        } else if (tileId < bit29 + bit31) {
-            minBitId = bit31;
-        } else if (tileId < bit30 + bit31) {
-            minBitId = bit29 + bit31;
-        } else if (tileId < bit29 + bit30 + bit31) {
-            minBitId = bit30 + bit31;
-        } else if (tileId < bit32) {
-            minBitId = bit29 + bit30 + bit31;
-        } else {
-            throw new Error(`Something was wrong with flipped tile id ${tileId}`);
+        if (tileset.imagewidth === undefined || tileset.imageheight === undefined) {
+            throw new Error(`Undefined image size on ${tileset.name} tileset`);
         }
 
-        const unflippedTileId = tileId - minBitId;
+        const tileBuffers = await Promise.all(
+            gids.map((gid) => {
+                const sourceTileset = tilesetIndex.getTileset(gid);
 
-        const existantNewTileId = this.optimizedTiles.get(unflippedTileId)?.global;
-
-        if (existantNewTileId) {
-            return existantNewTileId + minBitId;
-        }
-
-        let oldTileset: ITiledMapEmbeddedTileset | undefined;
-
-        for (const tileset of this.tilesetsBuffers.keys()) {
-            if (!tileset.firstgid) {
-                throw new Error(`firstgid property is undefined on ${tileset.name} tileset`);
-            }
-
-            if (!tileset.tilecount) {
-                throw new Error(`tilecount property is undefined on ${tileset.name} tileset`);
-            }
-
-            if (tileset.firstgid <= unflippedTileId && tileset.firstgid + tileset.tilecount > unflippedTileId) {
-                oldTileset = tileset;
-                break;
-            }
-        }
-
-        if (!oldTileset) {
-            if (this.logLevel) {
-                console.error(`${tileId} undefined! Corrupted layers or undefined in tilesets`);
-                console.error("This tile has been replaced by a empty tile");
-            }
-            return 0;
-        }
-
-        if (!oldTileset.firstgid) {
-            throw new Error(`firstgid property is undefined on ${oldTileset.name} tileset`);
-        }
-
-        const oldFirstgid = oldTileset.firstgid;
-        const oldTileIdInTileset = unflippedTileId - oldFirstgid;
-
-        let tileData: ITiledMapTile | undefined = undefined;
-
-        if (oldTileset.tiles) {
-            tileData = oldTileset.tiles.find((tile) => tile.id === oldTileIdInTileset);
-
-            if (tileData && tileData.animation) {
-                if (tileData.animation.length + this.currentExtractedTiles.length > this.tilesetMaxTileCount) {
-                    for (let i = 1; i < this.tilesetMaxTileCount - this.currentExtractedTiles.length; i++) {
-                        this.optimizedTiles.set(-1, {
-                            global: this.optimizedTiles.size + i,
-                            local: 0,
-                        });
-                    }
-
-                    await this.currentTilesetRendering();
-                }
-            }
-        }
-
-        const newTileId = this.optimizedTiles.size + 1;
-
-        this.optimizedTiles.set(unflippedTileId, {
-            global: newTileId,
-            local: this.currentExtractedTiles.length,
-        });
-
-        let newTileData: ITiledMapTile | undefined = undefined;
-
-        this.currentExtractedTiles.push(this.extractTile(oldTileset, unflippedTileId));
-
-        const newTileIdInTileset = this.currentExtractedTiles.length - 1;
-
-        if (oldTileset.properties) {
-            newTileData = {
-                id: newTileIdInTileset,
-                properties: [...oldTileset.properties],
-            };
-        }
-
-        if (!oldTileset.tiles) {
-            if (newTileData) {
-                this.currentTilesetOptimization.tiles?.push(newTileData);
-            }
-            return newTileId + minBitId;
-        }
-
-        if (!tileData) {
-            if (newTileData) {
-                this.currentTilesetOptimization.tiles?.push(newTileData);
-            }
-            return newTileId + minBitId;
-        }
-
-        if (!newTileData) {
-            newTileData = {
-                id: newTileIdInTileset,
-            };
-            this.currentTilesetOptimization.tiles?.push(newTileData);
-        }
-
-        if (tileData.properties) {
-            newTileData.properties
-                ? newTileData.properties.push(...tileData.properties)
-                : (newTileData.properties = [...tileData.properties]);
-            this.currentTilesetOptimization.tiles?.push(newTileData);
-        }
-
-        if (tileData.animation) {
-            newTileData.animation = [];
-            for (const frame of tileData.animation) {
-                await this.optimizeNewTile(oldFirstgid + frame.tileid);
-                const newTile = this.optimizedTiles.get(oldFirstgid + frame.tileid)?.local;
-                if (newTile === undefined) {
-                    throw new Error(`Undefined tile in animation for ${oldFirstgid + frame.tileid}`);
+                if (!sourceTileset) {
+                    throw new Error(`No source tileset found for tile ${gid}`);
                 }
 
-                newTileData.animation.push({
-                    duration: frame.duration,
-                    tileid: newTile,
-                });
-            }
-        }
-
-        return newTileId + minBitId;
-    }
-
-    private async extractTile(tileset: ITiledMapEmbeddedTileset, tileId: number): Promise<Buffer> {
-        if (!tileset.imagewidth) {
-            throw new Error(`imagewidth property is undefined on ${tileset.name} tileset`);
-        }
-
-        if (!tileset.firstgid) {
-            throw new Error(`firstgid property is undefined on ${tileset.name} tileset`);
-        }
-
-        const tileSizeSpaced = this.tileSize + (tileset.spacing || 0);
-        const tilesetColumns = Math.floor(
-            (tileset.imagewidth - (tileset.margin || 0) + (tileset.spacing || 0)) / tileSizeSpaced
-        );
-        const tilesetTileId = tileId - tileset.firstgid + 1;
-
-        const estimateLeft = tilesetTileId <= tilesetColumns ? tilesetTileId : tilesetTileId % tilesetColumns;
-        const leftStartPoint =
-            (estimateLeft === 0 ? tilesetColumns : estimateLeft) * tileSizeSpaced -
-            tileSizeSpaced +
-            (tileset.margin || 0);
-        let topStartPoint = tileset.margin || 0;
-        let state = tilesetTileId;
-
-        while (state > tilesetColumns) {
-            state -= tilesetColumns;
-            topStartPoint += tileSizeSpaced;
-        }
-
-        const sharpObject = this.tilesetsBuffers.get(tileset);
-
-        if (!sharpObject) {
-            throw new Error("Undefined sharp object");
-        }
-
-        return await sharpObject
-            .extract({
-                left: leftStartPoint,
-                top: topStartPoint,
-                width: this.tileSize,
-                height: this.tileSize,
+                return this.extractTile(sourceTileset, gid);
             })
-            .toBuffer();
-    }
+        );
 
-    private async checkCurrentTileset(): Promise<void> {
-        if (this.currentExtractedTiles.length < this.tilesetMaxTileCount) {
-            return;
-        }
-        await this.currentTilesetRendering();
-    }
-
-    private async currentTilesetRendering(): Promise<void> {
-        if (this.logLevel) {
-            console.log(`Rendering of ${this.currentTilesetOptimization.name} tileset...`);
-        }
-
-        this.currentTilesetOptimization.tilecount = this.currentExtractedTiles.length;
-        const columnCount = Math.ceil(Math.sqrt(this.currentTilesetOptimization.tilecount));
-        const imageSize = columnCount * this.tileSize;
-        this.currentTilesetOptimization.columns = columnCount;
-        this.currentTilesetOptimization.imagewidth = imageSize;
-        this.currentTilesetOptimization.imageheight = imageSize;
-
-        const tilesetBuffer = await this.generateNewTilesetBuffer(imageSize);
-
-        if (this.logLevel === LogLevel.VERBOSE) {
-            console.log("Empty image generated");
-        }
-
-        const sharpTileset = sharp(tilesetBuffer);
-
-        if (this.logLevel === LogLevel.VERBOSE) {
-            console.log("Loading of all tiles who will be optimized...");
-        }
-
-        const tileBuffers = await Promise.all(this.currentExtractedTiles);
-
-        if (this.logLevel === LogLevel.VERBOSE) {
-            console.log("Tiles loading finished");
-            console.log("Tileset optimized image generating...");
-        }
-
+        const emptyBuffer = await this.generateNewTilesetBuffer(tileset.imagewidth, tileset.imageheight);
         const sharpComposites: sharp.OverlayOptions[] = [];
 
         let x = 0;
         let y = 0;
 
         for (const tileBuffer of tileBuffers) {
-            if (x === imageSize) {
+            if (x === tileset.imagewidth) {
                 y += this.tileSize;
                 x = 0;
             }
@@ -449,21 +351,96 @@ export class Optimizer {
             x += this.tileSize;
         }
 
-        await sharpTileset
-            .composite(sharpComposites)
-            .toFile(`${this.outputPath}/${this.currentTilesetOptimization.image}`);
-
-        this.optimizedTilesets.push(this.currentTilesetOptimization);
+        await sharp(emptyBuffer).composite(sharpComposites).toFile(`${this.outputPath}/${tileset.image}`);
 
         if (this.logLevel === LogLevel.VERBOSE) {
-            console.log("Tileset optimized image generated");
+            console.log(`${tileset.name} tileset has been rendered`);
+        }
+    }
+
+    private async generateNewTilesetBuffer(width: number, height: number): Promise<Buffer> {
+        const newFile = new PNG({
+            width: width,
+            height: height,
+        });
+
+        return await newFile.pack().pipe(sharp()).toBuffer();
+    }
+
+    private async extractTile(tileset: ITiledMapEmbeddedTileset, gid: number): Promise<Buffer> {
+        if (!tileset.imagewidth) {
+            throw new Error(`imagewidth property is undefined on ${tileset.name} tileset`);
         }
 
-        if (this.logLevel) {
-            console.log("The tileset has been rendered");
+        if (tileset.firstgid === undefined) {
+            throw new Error(`firstgid property is undefined on ${tileset.name} tileset`);
         }
 
-        this.currentTilesetOptimization = this.generateNextTileset();
-        this.currentExtractedTiles = [];
+        const spacing = tileset.spacing ?? 0;
+        const margin = tileset.margin ?? 0;
+        const tileSizeSpaced = this.tileSize + spacing;
+        const columns = Math.floor((tileset.imagewidth - margin + spacing) / tileSizeSpaced);
+        const localId = gid - tileset.firstgid;
+        const left = margin + (localId % columns) * tileSizeSpaced;
+        const top = margin + Math.floor(localId / columns) * tileSizeSpaced;
+
+        const sharpObject = this.tilesetsBuffers.get(tileset);
+
+        if (!sharpObject) {
+            throw new Error("Undefined sharp object");
+        }
+
+        return await sharpObject
+            .extract({
+                left: left,
+                top: top,
+                width: this.tileSize,
+                height: this.tileSize,
+            })
+            .toBuffer();
+    }
+
+    private remapLayers(layers: ITiledMapLayer[], layerMappings: Map<ITiledMapLayer, Map<number, number>>): void {
+        for (const layer of layers) {
+            if (layer.type === "group") {
+                if (layer.layers) {
+                    this.remapLayers(layer.layers, layerMappings);
+                }
+                continue;
+            }
+
+            if (layer.type !== "tilelayer" || !layer.data) {
+                continue;
+            }
+
+            if (typeof layer.data === "string") {
+                if (this.logLevel) {
+                    console.warn(
+                        `Layer "${layer.name}" data is string-encoded and cannot be optimized: its tile ids will be broken in the output`
+                    );
+                }
+                continue;
+            }
+
+            const mapping = layerMappings.get(layer);
+
+            for (let i = 0; i < layer.data.length; i++) {
+                const rawGid = Number(layer.data[i]);
+
+                if (rawGid === 0) {
+                    continue;
+                }
+
+                const { gid, flipBits } = stripFlipBits(rawGid);
+                const newGid = mapping?.get(gid);
+
+                if (newGid === undefined) {
+                    layer.data[i] = 0;
+                    continue;
+                }
+
+                layer.data[i] = applyFlipBits(newGid, flipBits);
+            }
+        }
     }
 }

--- a/src/guards/libGuards.ts
+++ b/src/guards/libGuards.ts
@@ -8,6 +8,18 @@ export enum LogLevel {
 
 const isLogLevel = z.nativeEnum(LogLevel);
 
+const isPowerOfTwo = (value: number) => Number.isInteger(value) && value > 0 && (value & (value - 1)) === 0;
+
+/**
+ * Maximum size (in pixels) of an output tileset texture. Must be a power of 2 so the generated
+ * textures are GPU-friendly. Defaults to 4096.
+ */
+const isTilesetMaxSize = z
+    .number()
+    .gte(32)
+    .refine(isPowerOfTwo, { message: "Tileset size must be a power of 2" })
+    .optional();
+
 const isOptimizeBufferOptions = z.object({
     tile: z
         .object({
@@ -21,7 +33,7 @@ const isOptimizeBufferOptions = z.object({
                 .object({
                     prefix: z.string().optional(),
                     suffix: z.string().optional(),
-                    size: z.number().gte(32).multipleOf(8).optional(),
+                    size: isTilesetMaxSize,
                 })
                 .optional(),
         })
@@ -43,7 +55,7 @@ const isOptimizeOptions = isOptimizeBufferOptions.extend({
                 .object({
                     prefix: z.string().optional(),
                     suffix: z.string().optional(),
-                    size: z.number().gte(32).multipleOf(8).optional(),
+                    size: isTilesetMaxSize,
                     compress: z
                         .object({
                             quality: z.tuple([z.number().gte(0).lte(1), z.number().gte(0).lte(1)]).optional(),

--- a/tests/clustering.test.ts
+++ b/tests/clustering.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import { ClusterInput, clusterLayers, slotsFor } from "../src/Clustering.js";
+import { applyFlipBits, stripFlipBits } from "../src/LayerAnalysis.js";
+
+function input(index: number, tiles: number[]): ClusterInput {
+    return { index, name: `layer-${index}`, tiles: new Set(tiles) };
+}
+
+function range(start: number, count: number): number[] {
+    return Array.from({ length: count }, (_, i) => start + i);
+}
+
+describe("slotsFor", () => {
+    it("returns the smallest power of 2 above the tile count", () => {
+        expect(slotsFor(0)).toBe(1);
+        expect(slotsFor(1)).toBe(1);
+        expect(slotsFor(2)).toBe(2);
+        expect(slotsFor(3)).toBe(4);
+        expect(slotsFor(1024)).toBe(1024);
+        expect(slotsFor(1025)).toBe(2048);
+    });
+});
+
+describe("clusterLayers", () => {
+    it("puts a single layer in a single cluster", () => {
+        const clusters = clusterLayers([input(0, [1, 2, 3])], 256);
+
+        expect(clusters).toHaveLength(1);
+        expect(clusters[0].tiles).toEqual(new Set([1, 2, 3]));
+        expect(clusters[0].oversized).toBe(false);
+    });
+
+    it("skips layers without tiles", () => {
+        const clusters = clusterLayers([input(0, []), input(1, [1])], 256);
+
+        expect(clusters).toHaveLength(1);
+        expect(clusters[0].members.map((member) => member.index)).toEqual([1]);
+    });
+
+    it("merges identical layers into one cluster", () => {
+        const clusters = clusterLayers([input(0, [1, 2]), input(1, [1, 2])], 256);
+
+        expect(clusters).toHaveLength(1);
+        expect(clusters[0].tiles).toEqual(new Set([1, 2]));
+    });
+
+    it("merges small disjoint layers to amortize the per-tileset cost", () => {
+        const clusters = clusterLayers([input(0, [1, 2]), input(1, [10, 11])], 256);
+
+        expect(clusters).toHaveLength(1);
+        expect(clusters[0].tiles).toEqual(new Set([1, 2, 10, 11]));
+    });
+
+    it("does not merge beyond the capacity", () => {
+        const clusters = clusterLayers([input(0, range(0, 6)), input(1, range(100, 6))], 8);
+
+        expect(clusters).toHaveLength(2);
+    });
+
+    it("prefers merging overlapping layers when the capacity is tight", () => {
+        // A and B share 5 tiles, C is disjoint. Capacity 8 only allows one merge: A+B.
+        const clusters = clusterLayers(
+            [input(0, range(0, 5)), input(1, [...range(0, 5), 6]), input(2, range(100, 5))],
+            8
+        );
+
+        expect(clusters).toHaveLength(2);
+        expect(clusters[0].members.map((member) => member.index)).toEqual([0, 1]);
+        expect(clusters[0].tiles.size).toBe(6);
+        expect(clusters[1].members.map((member) => member.index)).toEqual([2]);
+    });
+
+    it("flags a layer bigger than the capacity as oversized and never merges it", () => {
+        const clusters = clusterLayers([input(0, range(0, 20)), input(1, [1, 2])], 16);
+
+        expect(clusters).toHaveLength(2);
+        expect(clusters[0].oversized).toBe(true);
+        expect(clusters[0].members.map((member) => member.index)).toEqual([0]);
+        expect(clusters[1].oversized).toBe(false);
+    });
+
+    it("merges everything into one tileset when the whole map fits", () => {
+        const layers = [
+            input(0, range(0, 100)),
+            input(1, range(50, 100)),
+            input(2, range(200, 30)),
+            input(3, [5, 6, 7]),
+        ];
+
+        const clusters = clusterLayers(layers, 16384);
+
+        expect(clusters).toHaveLength(1);
+        expect(clusters[0].members.map((member) => member.index)).toEqual([0, 1, 2, 3]);
+    });
+
+    it("is deterministic: same input twice gives the same output", () => {
+        const layers = () => [
+            input(0, range(0, 60)),
+            input(1, range(30, 60)),
+            input(2, range(200, 60)),
+            input(3, range(230, 60)),
+        ];
+
+        const first = clusterLayers(layers(), 128);
+        const second = clusterLayers(layers(), 128);
+
+        expect(second).toEqual(first);
+    });
+});
+
+describe("flip bits", () => {
+    it("round-trips flipped gids, including bit 31", () => {
+        const flippedGid = 2147483648 + 1073741824 + 42; // horizontal + vertical flips on tile 42
+
+        const { gid, flipBits } = stripFlipBits(flippedGid);
+
+        expect(gid).toBe(42);
+        expect(applyFlipBits(7, flipBits)).toBe(2147483648 + 1073741824 + 7);
+    });
+
+    it("leaves unflipped gids untouched", () => {
+        const { gid, flipBits } = stripFlipBits(1500);
+
+        expect(gid).toBe(1500);
+        expect(flipBits).toBe(0);
+        expect(applyFlipBits(gid, flipBits)).toBe(1500);
+    });
+});

--- a/tests/optimizer.test.ts
+++ b/tests/optimizer.test.ts
@@ -1,0 +1,154 @@
+import { ITiledMap, ITiledMapEmbeddedTileset, ITiledMapLayer } from "@workadventure/tiled-map-type-guard";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import sharp from "sharp";
+import { afterAll, describe, expect, it } from "vitest";
+import { slotsFor } from "../src/Clustering.js";
+import { Optimizer } from "../src/Optimizer.js";
+
+const TILE = 8;
+
+const tmpDirs: string[] = [];
+
+afterAll(() => {
+    for (const dir of tmpDirs) {
+        fs.rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+/**
+ * A single blank source tileset holding `columns * rows` tiles, plus its Sharp buffer. Pixels are
+ * irrelevant here — the tests only assert on the emitted GID bookkeeping, not on rendered images.
+ */
+function sourceTileset(columns: number, rows: number): { tileset: ITiledMapEmbeddedTileset; buffer: sharp.Sharp } {
+    const width = columns * TILE;
+    const height = rows * TILE;
+    const raw = Buffer.alloc(width * height * 4, 0);
+    const buffer = sharp(raw, { raw: { width, height, channels: 4 } }).png();
+
+    const tileset = {
+        columns,
+        firstgid: 1,
+        image: "source.png",
+        imageheight: height,
+        imagewidth: width,
+        margin: 0,
+        name: "source",
+        spacing: 0,
+        tilecount: columns * rows,
+        tileheight: TILE,
+        tilewidth: TILE,
+    } as ITiledMapEmbeddedTileset;
+
+    return { tileset, buffer };
+}
+
+function tileLayer(name: string, gids: number[]): ITiledMapLayer {
+    return {
+        type: "tilelayer",
+        name,
+        data: gids,
+        width: gids.length,
+        height: 1,
+        x: 0,
+        y: 0,
+        opacity: 1,
+        visible: true,
+    } as unknown as ITiledMapLayer;
+}
+
+/**
+ * Runs the real optimizer on a synthetic map made of the given layers (all referencing one blank
+ * source tileset big enough to hold every gid) and returns the emitted tilesets.
+ */
+async function optimize(layers: ITiledMapLayer[], tilesetSize: number): Promise<ITiledMapEmbeddedTileset[]> {
+    const maxGid = Math.max(...layers.flatMap((layer) => layer.data as number[]));
+    const columns = 16;
+    const rows = Math.ceil(maxGid / columns);
+    const source = sourceTileset(columns, rows);
+
+    const map = { layers, tilesets: [source.tileset] } as unknown as ITiledMap;
+    const buffers = new Map<ITiledMapEmbeddedTileset, sharp.Sharp>([[source.tileset, source.buffer]]);
+
+    const outputPath = fs.mkdtempSync(path.join(os.tmpdir(), "wa-opt-"));
+    tmpDirs.push(outputPath);
+
+    const optimizer = new Optimizer(
+        map,
+        buffers,
+        { tile: { size: TILE }, logs: 0, output: { tileset: { size: tilesetSize } } },
+        outputPath
+    );
+
+    const result = await optimizer.optimize();
+    return result.tilesets as ITiledMapEmbeddedTileset[];
+}
+
+function range(start: number, count: number): number[] {
+    return Array.from({ length: count }, (_, i) => start + i);
+}
+
+function capacity(tileset: ITiledMapEmbeddedTileset): number {
+    return (tileset.columns ?? 0) * ((tileset.imageheight ?? 0) / TILE);
+}
+
+/**
+ * The core invariant: every tileset reserves its full image-grid capacity as GIDs, and no two
+ * tilesets' [firstgid, firstgid + tilecount) ranges intersect. Phaser derives a tileset's tile
+ * count from the image dimensions and ignores `tilecount`, so a violation of this silently drops
+ * tiles on classic TilemapLayer rendering.
+ */
+function expectNoOverlappingGidRanges(tilesets: ITiledMapEmbeddedTileset[]): void {
+    for (const tileset of tilesets) {
+        expect(tileset.tilecount).toBe(capacity(tileset));
+    }
+
+    const sorted = [...tilesets].sort((a, b) => (a.firstgid ?? 0) - (b.firstgid ?? 0));
+    for (let i = 1; i < sorted.length; i++) {
+        const prev = sorted[i - 1];
+        const curr = sorted[i];
+        expect(curr.firstgid ?? 0).toBeGreaterThanOrEqual((prev.firstgid ?? 0) + (prev.tilecount ?? 0));
+    }
+}
+
+describe("Optimizer GID ranges", () => {
+    it("reserves the full image-grid capacity as tilecount, not the used tile count", async () => {
+        // 40 tiles -> smallest power-of-2 grid is 64 slots (8x8). The tileset must claim all 64.
+        const tilesets = await optimize([tileLayer("floor", range(1, 40))], 64);
+
+        expect(tilesets).toHaveLength(1);
+        expect(tilesets[0].firstgid).toBe(1);
+        expect(tilesets[0].tilecount).toBe(slotsFor(40));
+        expect(tilesets[0].tilecount).toBe(capacity(tilesets[0]));
+    });
+
+    it("keeps consecutive tilesets' GID ranges from overlapping when a chunk is not power-of-2", async () => {
+        // Two disjoint 40-tile layers (union 80 > capacity 64) render as two separate tilesets.
+        // Each holds 40 tiles in a 64-slot image; advancing firstgid by 40 instead of 64 would make
+        // the second tileset's range overlap the first's padded tail — the original bug.
+        const tilesets = await optimize([tileLayer("floor", range(1, 40)), tileLayer("furniture", range(100, 40))], 64);
+
+        expect(tilesets).toHaveLength(2);
+        const sorted = [...tilesets].sort((a, b) => (a.firstgid ?? 0) - (b.firstgid ?? 0));
+        expect(sorted[0].firstgid).toBe(1);
+        expect(sorted[1].firstgid).toBe(1 + slotsFor(40)); // 65, not 41
+        expectNoOverlappingGidRanges(tilesets);
+    });
+
+    it("splits an oversized layer into non-overlapping tilesets alongside another layer", async () => {
+        // 150 tiles > capacity 64 -> the layer is split into 64 + 64 + 22 tiles. The trailing 22-tile
+        // chunk pads to a 32-slot image; a second disjoint layer follows it. This mirrors the
+        // wa-headquarters GroundWorld/AboveWorld case where furniture went missing.
+        const tilesets = await optimize([tileLayer("world", range(1, 150)), tileLayer("signs", range(200, 5))], 64);
+
+        expect(tilesets.length).toBeGreaterThanOrEqual(3);
+        expectNoOverlappingGidRanges(tilesets);
+
+        // Ranges are contiguous: each firstgid stride equals the previous tileset's capacity.
+        const sorted = [...tilesets].sort((a, b) => (a.firstgid ?? 0) - (b.firstgid ?? 0));
+        for (let i = 1; i < sorted.length; i++) {
+            expect(sorted[i].firstgid).toBe((sorted[i - 1].firstgid ?? 0) + capacity(sorted[i - 1]));
+        }
+    });
+});


### PR DESCRIPTION
## Why

Phaser 4's `TilemapGPULayer` can only render a layer whose tiles all come from a **single tileset**. The previous optimizer was a streaming chunker: it filled fixed-size 512px tilesets in tile-discovery order, scattering each layer's tiles across arbitrary chunks — the worst case for GPU layers.

## What

The optimizer is refactored into three explicit passes:

1. **Analysis** (`src/LayerAnalysis.ts`): collect each layer's set of unflipped tile GIDs, expanded with animation closures (frame ids are tileset-local in the Tiled format, so frames must stay with their base tile). Named tiles used by no layer are gathered into a pseudo-layer. The old `-1` padding hack for animations straddling chunk boundaries is gone.
2. **Clustering** (`src/Clustering.ts`, pure & unit-tested): greedy agglomerative clustering of layers — each cluster becomes one tileset holding the union of its layers' tiles. Cost function = power-of-2 padded slots + a fixed per-tileset overhead, so clusters merge until the max texture size is reached, high-overlap pairs first, which minimizes tile duplication across tilesets.
3. **Rendering** (`src/Optimizer.ts`): one rectangular power-of-2 texture per cluster (e.g. 2048×1024, as square as possible), per-layer GID remapping, tile properties and animations preserved.

A single layer using more tiles than one tileset can hold is **never split**: it is rendered with several tilesets and a loud warning (that layer loses GPU eligibility; all other layers keep the guarantee).

A step-by-step description of the algorithm is committed as [`docs/algorithm.md`](https://github.com/moufmouf/wa-map-optimizer/blob/feat/phaser4-gpu-layer-tilesets/docs/algorithm.md), linked from the README.

## Results on real maps

On `example/vsl-travel-hub` (24 tile layers, 2,023 unique tiles): **one single 2048×1024 tileset instead of 39 chunks**, all layers GPU-eligible, 0 duplicated tiles, 1.2% padding waste.

Stress test with the cap forced to 512px: the two genuinely oversized layers warn and split; the 22 others each keep exactly one tileset.

## Verification

- `npm run build`, `npm run typecheck`, `npm run lint`, `npm test` (12 new vitest unit tests, now also run in CI)
- Invariant checks on both example maps: every layer's GIDs fall within a single tileset range, all animation frame ids are tileset-local, all named tiles preserved
- Pixel comparison of 100+ sampled map cells against the source tilesets: identical (up to ±1 rounding on semi-transparent pixels from sharp's premultiplied-alpha compositing, which the previous version had too)
- Animation audit: all 90 layer-reachable animated tiles of the source survive with their frames (the other 173 are unused and correctly pruned)

## BREAKING CHANGE

`output.tileset.size` now means the **maximum** texture size (must be a power of 2, default **4096**) instead of the fixed 512px chunk size, and output tilesets are laid out per layer cluster rather than as sequential fixed-size chunks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
