### PR TITLE
perf: speed up tileset rendering ~19x (raw pixel pipeline)

### DIFF
--- a/src/Optimizer.ts
+++ b/src/Optimizer.ts
@@ -351,7 +351,12 @@ export class Optimizer {
             }
 
             sharpComposites.push({
-                input: tileBuffer,
+                input: tileBuffer.buffer,
+                raw: {
+                    width: this.tileSize,
+                    height: this.tileSize,
+                    channels: tileBuffer.channels,
+                },
                 top: y,
                 left: x,
             });
@@ -375,7 +380,10 @@ export class Optimizer {
         return await newFile.pack().pipe(sharp()).toBuffer();
     }
 
-    private async extractTile(tileset: ITiledMapEmbeddedTileset, gid: number): Promise<Buffer> {
+    private async extractTile(
+        tileset: ITiledMapEmbeddedTileset,
+        gid: number
+    ): Promise<{ buffer: Buffer; channels: 1 | 2 | 3 | 4 }> {
         if (!tileset.imagewidth) {
             throw new Error(`imagewidth property is undefined on ${tileset.name} tileset`);
         }
@@ -398,14 +406,20 @@ export class Optimizer {
             throw new Error("Undefined sharp object");
         }
 
-        return await sharpObject
+        // Return raw (already-decoded) pixels instead of a PNG. The source is held in memory as a
+        // raw buffer, so encoding each 32x32 tile to PNG here only to have composite() decode it
+        // again is pure overhead. Raw buffers let composite() blend them directly.
+        const { data, info } = await sharpObject
             .extract({
                 left: left,
                 top: top,
                 width: this.tileSize,
                 height: this.tileSize,
             })
-            .toBuffer();
+            .raw()
+            .toBuffer({ resolveWithObject: true });
+
+        return { buffer: data, channels: info.channels };
     }
 
     /**

--- a/src/Optimizer.ts
+++ b/src/Optimizer.ts
@@ -42,7 +42,7 @@ export class Optimizer {
     private logLevel: LogLevel;
     // Each source tileset decoded to raw RGBA pixels exactly once. Tiles are then sliced out of
     // these buffers with plain memory copies instead of a per-tile sharp/libvips extract() call.
-    private readonly sourceRaws = new Map<ITiledMapEmbeddedTileset, { data: Buffer; width: number }>();
+    private readonly sourceRaws = new Map<ITiledMapEmbeddedTileset, { data: Buffer; width: number; height: number }>();
 
     constructor(
         map: ITiledMap,
@@ -365,6 +365,15 @@ export class Optimizer {
             }
 
             const { left, top } = this.tileLocation(sourceTileset, gid);
+
+            // sharp's extract() used to throw on an out-of-range crop; Buffer.copy() would instead
+            // silently truncate and emit a corrupt tile. Keep the loud failure for bad metadata.
+            if (left < 0 || top < 0 || left + this.tileSize > source.width || top + this.tileSize > source.height) {
+                throw new Error(
+                    `Tile ${gid} maps to an out-of-bounds source rect [${left},${top} +${this.tileSize}] in the ${source.width}x${source.height} tileset ${sourceTileset.name}`
+                );
+            }
+
             const srcStride = source.width * channels;
 
             for (let row = 0; row < this.tileSize; row++) {
@@ -391,7 +400,27 @@ export class Optimizer {
     private async loadSourceRaws(): Promise<void> {
         for (const [tileset, sharpObject] of this.tilesetsBuffers) {
             const { data, info } = await sharpObject.ensureAlpha().raw().toBuffer({ resolveWithObject: true });
-            this.sourceRaws.set(tileset, { data, width: info.width });
+
+            // The render loop assumes a fixed 4-channel (RGBA) stride; ensureAlpha() guarantees it
+            // for RGB/RGBA sources but not e.g. a grayscale image (which yields 2 channels).
+            if (info.channels !== 4) {
+                throw new Error(
+                    `Tileset ${tileset.name} decoded to ${info.channels} channels after ensureAlpha(), expected 4 (RGBA). Is it a grayscale image?`
+                );
+            }
+
+            // tileLocation() derives tile columns from the metadata width, while the copy loop uses
+            // the decoded width for its stride. If they disagree, tiles would be read from the wrong
+            // offsets — silently, since the reads could still land in bounds. Fail loudly instead.
+            if (tileset.imagewidth !== info.width || tileset.imageheight !== info.height) {
+                throw new Error(
+                    `Tileset ${tileset.name} metadata size ${tileset.imagewidth ?? "?"}x${
+                        tileset.imageheight ?? "?"
+                    } does not match the decoded image ${info.width}x${info.height}`
+                );
+            }
+
+            this.sourceRaws.set(tileset, { data, width: info.width, height: info.height });
         }
     }
 

--- a/src/Optimizer.ts
+++ b/src/Optimizer.ts
@@ -4,7 +4,6 @@ import {
     ITiledMapLayer,
     ITiledMapTile,
 } from "@workadventure/tiled-map-type-guard";
-import { PNG } from "pngjs";
 import sharp, { Sharp } from "sharp";
 import { Cluster, clusterLayers, slotsFor } from "./Clustering.js";
 import {
@@ -338,52 +337,45 @@ export class Optimizer {
             })
         );
 
-        const emptyBuffer = await this.generateNewTilesetBuffer(tileset.imagewidth, tileset.imageheight);
-        const sharpComposites: sharp.OverlayOptions[] = [];
+        // The tiles form a regular, non-overlapping grid on a transparent canvas, so "compositing"
+        // them is really just placing each tile's pixels into its own cell — a memory copy. Handing
+        // thousands of tiles to sharp/libvips composite() instead makes it run its general N-layer
+        // alpha compositor, whose cost scales with the number of layers (per-tile bookkeeping), not
+        // the pixels moved — the dominant cost on large maps. We assemble the raw RGBA buffer here
+        // with plain row copies and let sharp encode the finished image exactly once.
+        const channels = 4;
+        const width = tileset.imagewidth;
+        const height = tileset.imageheight;
+        const rowBytes = this.tileSize * channels;
+        const destStride = width * channels;
+        const dest = Buffer.alloc(width * height * channels); // zero-filled == fully transparent
 
         let x = 0;
         let y = 0;
 
         for (const tileBuffer of tileBuffers) {
-            if (x === tileset.imagewidth) {
+            if (x === width) {
                 y += this.tileSize;
                 x = 0;
             }
 
-            sharpComposites.push({
-                input: tileBuffer.buffer,
-                raw: {
-                    width: this.tileSize,
-                    height: this.tileSize,
-                    channels: tileBuffer.channels,
-                },
-                top: y,
-                left: x,
-            });
+            for (let row = 0; row < this.tileSize; row++) {
+                const srcStart = row * rowBytes;
+                const destStart = (y + row) * destStride + x * channels;
+                tileBuffer.copy(dest, destStart, srcStart, srcStart + rowBytes);
+            }
 
             x += this.tileSize;
         }
 
-        await sharp(emptyBuffer).composite(sharpComposites).toFile(`${this.outputPath}/${tileset.image}`);
+        await sharp(dest, { raw: { width, height, channels } }).png().toFile(`${this.outputPath}/${tileset.image}`);
 
         if (this.logLevel === LogLevel.VERBOSE) {
             console.log(`${tileset.name} tileset has been rendered`);
         }
     }
 
-    private async generateNewTilesetBuffer(width: number, height: number): Promise<Buffer> {
-        const newFile = new PNG({
-            width: width,
-            height: height,
-        });
-
-        return await newFile.pack().pipe(sharp()).toBuffer();
-    }
-
-    private async extractTile(
-        tileset: ITiledMapEmbeddedTileset,
-        gid: number
-    ): Promise<{ buffer: Buffer; channels: 1 | 2 | 3 | 4 }> {
+    private async extractTile(tileset: ITiledMapEmbeddedTileset, gid: number): Promise<Buffer> {
         if (!tileset.imagewidth) {
             throw new Error(`imagewidth property is undefined on ${tileset.name} tileset`);
         }
@@ -406,20 +398,20 @@ export class Optimizer {
             throw new Error("Undefined sharp object");
         }
 
-        // Return raw (already-decoded) pixels instead of a PNG. The source is held in memory as a
-        // raw buffer, so encoding each 32x32 tile to PNG here only to have composite() decode it
-        // again is pure overhead. Raw buffers let composite() blend them directly.
-        const { data, info } = await sharpObject
+        // Return raw (already-decoded) RGBA pixels. The source is held in memory as a raw buffer, so
+        // encoding each 32x32 tile to PNG here would be pure overhead. ensureAlpha() forces a uniform
+        // 4-channel layout (opaque alpha for RGB sources) so renderTileset can copy every tile's rows
+        // into the destination buffer with a single fixed stride.
+        return await sharpObject
             .extract({
                 left: left,
                 top: top,
                 width: this.tileSize,
                 height: this.tileSize,
             })
+            .ensureAlpha()
             .raw()
-            .toBuffer({ resolveWithObject: true });
-
-        return { buffer: data, channels: info.channels };
+            .toBuffer();
     }
 
     /**

--- a/src/Optimizer.ts
+++ b/src/Optimizer.ts
@@ -341,8 +341,6 @@ export class Optimizer {
         const channels = 4;
         const width = tileset.imagewidth;
         const height = tileset.imageheight;
-        const rowBytes = this.tileSize * channels;
-        const destStride = width * channels;
         const dest = Buffer.alloc(width * height * channels); // zero-filled == fully transparent
 
         let x = 0;
@@ -374,13 +372,7 @@ export class Optimizer {
                 );
             }
 
-            const srcStride = source.width * channels;
-
-            for (let row = 0; row < this.tileSize; row++) {
-                const srcStart = (top + row) * srcStride + left * channels;
-                const destStart = (y + row) * destStride + x * channels;
-                source.data.copy(dest, destStart, srcStart, srcStart + rowBytes);
-            }
+            this.blitTile(source, left, top, dest, width, x, y);
 
             x += this.tileSize;
         }
@@ -389,6 +381,33 @@ export class Optimizer {
 
         if (this.logLevel === LogLevel.VERBOSE) {
             console.log(`${tileset.name} tileset has been rendered`);
+        }
+    }
+
+    /**
+     * Copy one tileSize×tileSize RGBA tile from a source image buffer into a destination image
+     * buffer, row by row. This is a straight memory copy, not an alpha composite: output tiles sit
+     * on a non-overlapping grid over a transparent canvas, so each destination cell is written
+     * exactly once and there is nothing to blend against. See renderTileset for why that matters.
+     */
+    private blitTile(
+        source: { data: Buffer; width: number },
+        srcLeft: number,
+        srcTop: number,
+        dest: Buffer,
+        destWidth: number,
+        destLeft: number,
+        destTop: number
+    ): void {
+        const channels = 4;
+        const rowBytes = this.tileSize * channels;
+        const srcStride = source.width * channels;
+        const destStride = destWidth * channels;
+
+        for (let row = 0; row < this.tileSize; row++) {
+            const srcStart = (srcTop + row) * srcStride + srcLeft * channels;
+            const destStart = (destTop + row) * destStride + destLeft * channels;
+            source.data.copy(dest, destStart, srcStart, srcStart + rowBytes);
         }
     }
 

--- a/src/Optimizer.ts
+++ b/src/Optimizer.ts
@@ -40,6 +40,9 @@ export class Optimizer {
     private tilesetPrefix: string;
     private tilesetSuffix?: string;
     private logLevel: LogLevel;
+    // Each source tileset decoded to raw RGBA pixels exactly once. Tiles are then sliced out of
+    // these buffers with plain memory copies instead of a per-tile sharp/libvips extract() call.
+    private readonly sourceRaws = new Map<ITiledMapEmbeddedTileset, { data: Buffer; width: number }>();
 
     constructor(
         map: ITiledMap,
@@ -132,6 +135,8 @@ export class Optimizer {
         }
 
         // Pass 3: rendering & remapping
+        await this.loadSourceRaws();
+
         const layerMappings = new Map<ITiledMapLayer, Map<number, number>>();
         const newTilesets: ITiledMapEmbeddedTileset[] = [];
         let firstgid = 1;
@@ -325,24 +330,14 @@ export class Optimizer {
             throw new Error(`Undefined image size on ${tileset.name} tileset`);
         }
 
-        const tileBuffers = await Promise.all(
-            gids.map((gid) => {
-                const sourceTileset = tilesetIndex.getTileset(gid);
-
-                if (!sourceTileset) {
-                    throw new Error(`No source tileset found for tile ${gid}`);
-                }
-
-                return this.extractTile(sourceTileset, gid);
-            })
-        );
-
         // The tiles form a regular, non-overlapping grid on a transparent canvas, so "compositing"
         // them is really just placing each tile's pixels into its own cell — a memory copy. Handing
         // thousands of tiles to sharp/libvips composite() instead makes it run its general N-layer
         // alpha compositor, whose cost scales with the number of layers (per-tile bookkeeping), not
-        // the pixels moved — the dominant cost on large maps. We assemble the raw RGBA buffer here
-        // with plain row copies and let sharp encode the finished image exactly once.
+        // the pixels moved. Likewise, extracting each tile with a per-tile sharp extract() call is
+        // thousands of round-trips into libvips over source pixels we already hold in memory. We
+        // copy each tile's rows straight from the cached source buffer into the destination buffer
+        // and let sharp encode the finished image exactly once.
         const channels = 4;
         const width = tileset.imagewidth;
         const height = tileset.imageheight;
@@ -353,16 +348,29 @@ export class Optimizer {
         let x = 0;
         let y = 0;
 
-        for (const tileBuffer of tileBuffers) {
+        for (const gid of gids) {
             if (x === width) {
                 y += this.tileSize;
                 x = 0;
             }
 
+            const sourceTileset = tilesetIndex.getTileset(gid);
+            if (!sourceTileset) {
+                throw new Error(`No source tileset found for tile ${gid}`);
+            }
+
+            const source = this.sourceRaws.get(sourceTileset);
+            if (!source) {
+                throw new Error(`No decoded source pixels for tileset ${sourceTileset.name}`);
+            }
+
+            const { left, top } = this.tileLocation(sourceTileset, gid);
+            const srcStride = source.width * channels;
+
             for (let row = 0; row < this.tileSize; row++) {
-                const srcStart = row * rowBytes;
+                const srcStart = (top + row) * srcStride + left * channels;
                 const destStart = (y + row) * destStride + x * channels;
-                tileBuffer.copy(dest, destStart, srcStart, srcStart + rowBytes);
+                source.data.copy(dest, destStart, srcStart, srcStart + rowBytes);
             }
 
             x += this.tileSize;
@@ -375,7 +383,23 @@ export class Optimizer {
         }
     }
 
-    private async extractTile(tileset: ITiledMapEmbeddedTileset, gid: number): Promise<Buffer> {
+    /**
+     * Decode every source tileset image to raw RGBA pixels exactly once and cache it. ensureAlpha()
+     * forces a uniform 4-channel layout (opaque alpha for RGB sources) so tiles can be sliced with a
+     * single fixed stride, and matches the transparent-over-RGBA canvas the tiles are drawn onto.
+     */
+    private async loadSourceRaws(): Promise<void> {
+        for (const [tileset, sharpObject] of this.tilesetsBuffers) {
+            const { data, info } = await sharpObject.ensureAlpha().raw().toBuffer({ resolveWithObject: true });
+            this.sourceRaws.set(tileset, { data, width: info.width });
+        }
+    }
+
+    /**
+     * Pixel coordinates of a tile's top-left corner within its source image, honouring the source
+     * tileset's margin and inter-tile spacing.
+     */
+    private tileLocation(tileset: ITiledMapEmbeddedTileset, gid: number): { left: number; top: number } {
         if (!tileset.imagewidth) {
             throw new Error(`imagewidth property is undefined on ${tileset.name} tileset`);
         }
@@ -392,26 +416,7 @@ export class Optimizer {
         const left = margin + (localId % columns) * tileSizeSpaced;
         const top = margin + Math.floor(localId / columns) * tileSizeSpaced;
 
-        const sharpObject = this.tilesetsBuffers.get(tileset);
-
-        if (!sharpObject) {
-            throw new Error("Undefined sharp object");
-        }
-
-        // Return raw (already-decoded) RGBA pixels. The source is held in memory as a raw buffer, so
-        // encoding each 32x32 tile to PNG here would be pure overhead. ensureAlpha() forces a uniform
-        // 4-channel layout (opaque alpha for RGB sources) so renderTileset can copy every tile's rows
-        // into the destination buffer with a single fixed stride.
-        return await sharpObject
-            .extract({
-                left: left,
-                top: top,
-                width: this.tileSize,
-                height: this.tileSize,
-            })
-            .ensureAlpha()
-            .raw()
-            .toBuffer();
+        return { left, top };
     }
 
     /**

--- a/tests/optimizer.test.ts
+++ b/tests/optimizer.test.ts
@@ -44,6 +44,53 @@ function sourceTileset(columns: number, rows: number): { tileset: ITiledMapEmbed
     return { tileset, buffer };
 }
 
+type Rgba = [number, number, number, number];
+
+/**
+ * A source tileset whose tiles are each filled with a distinct solid RGBA colour, laid out
+ * left-to-right, top-to-bottom. Unlike `sourceTileset`, pixels matter here: the rendering test
+ * decodes the optimized output and asserts each tile landed at the right position with its colour
+ * and alpha intact.
+ */
+function coloredSource(colors: Rgba[], columns: number): { tileset: ITiledMapEmbeddedTileset; buffer: sharp.Sharp } {
+    const rows = Math.ceil(colors.length / columns);
+    const width = columns * TILE;
+    const height = rows * TILE;
+    const raw = Buffer.alloc(width * height * 4, 0);
+
+    colors.forEach((color, i) => {
+        const originX = (i % columns) * TILE;
+        const originY = Math.floor(i / columns) * TILE;
+        for (let py = 0; py < TILE; py++) {
+            for (let px = 0; px < TILE; px++) {
+                const offset = ((originY + py) * width + (originX + px)) * 4;
+                raw[offset] = color[0];
+                raw[offset + 1] = color[1];
+                raw[offset + 2] = color[2];
+                raw[offset + 3] = color[3];
+            }
+        }
+    });
+
+    const buffer = sharp(raw, { raw: { width, height, channels: 4 } }).png();
+
+    const tileset = {
+        columns,
+        firstgid: 1,
+        image: "source.png",
+        imageheight: height,
+        imagewidth: width,
+        margin: 0,
+        name: "source",
+        spacing: 0,
+        tilecount: colors.length,
+        tileheight: TILE,
+        tilewidth: TILE,
+    } as ITiledMapEmbeddedTileset;
+
+    return { tileset, buffer };
+}
+
 function tileLayer(name: string, gids: number[]): ITiledMapLayer {
     return {
         type: "tilelayer",
@@ -150,5 +197,54 @@ describe("Optimizer GID ranges", () => {
         for (let i = 1; i < sorted.length; i++) {
             expect(sorted[i].firstgid).toBe((sorted[i - 1].firstgid ?? 0) + capacity(sorted[i - 1]));
         }
+    });
+});
+
+describe("Optimizer pixel rendering", () => {
+    it("places each tile's pixels and alpha at the correct position in the output image", async () => {
+        // Four distinct tiles. The last is semi-transparent: the raw-copy pipeline must preserve its
+        // colour and alpha exactly (no premultiplication), and drop it at the right cell.
+        const colors: Rgba[] = [
+            [255, 0, 0, 255], // gid 1
+            [0, 255, 0, 255], // gid 2
+            [0, 0, 255, 255], // gid 3
+            [10, 20, 30, 128], // gid 4 (semi-transparent)
+        ];
+        const source = coloredSource(colors, 2);
+
+        const map = {
+            layers: [tileLayer("floor", [1, 2, 3, 4])],
+            tilesets: [source.tileset],
+        } as unknown as ITiledMap;
+        const buffers = new Map<ITiledMapEmbeddedTileset, sharp.Sharp>([[source.tileset, source.buffer]]);
+
+        const outputPath = fs.mkdtempSync(path.join(os.tmpdir(), "wa-opt-"));
+        tmpDirs.push(outputPath);
+
+        const optimizer = new Optimizer(
+            map,
+            buffers,
+            { tile: { size: TILE }, logs: 0, output: { tileset: { size: 64 } } },
+            outputPath
+        );
+        const result = await optimizer.optimize();
+
+        expect(result.tilesets).toHaveLength(1);
+        const image = result.tilesets[0] as ITiledMapEmbeddedTileset;
+        const outColumns = image.columns ?? 0;
+
+        const { data, info } = await sharp(path.join(outputPath, image.image as string))
+            .ensureAlpha()
+            .raw()
+            .toBuffer({ resolveWithObject: true });
+
+        // Tiles are emitted in sorted-gid order, so local id i corresponds to gid i+1 (colors[i]) and
+        // sits at grid cell (i % columns, i / columns). Sample the centre of each cell.
+        colors.forEach((color, i) => {
+            const px = (i % outColumns) * TILE + Math.floor(TILE / 2);
+            const py = Math.floor(i / outColumns) * TILE + Math.floor(TILE / 2);
+            const offset = (py * info.width + px) * 4;
+            expect([data[offset], data[offset + 1], data[offset + 2], data[offset + 3]]).toEqual(color);
+        });
     });
 });


### PR DESCRIPTION
Speeds up the tileset-rendering pass, the dominant cost when optimizing large maps. Three independent fixes, all about how the code drives `sharp`/libvips. The source tilesets are already held in memory as raw pixels, so the whole pass can be plain memory copies with a single decode in and a single encode out.

## 1. Stop round-tripping every tile through PNG

The shared `Sharp` object had `.png()` as its output format, so the render pass PNG-encoded each 32×32 tile and then decoded it again to place it. Tiles are now handled as raw pixels.

## 2. Assemble the tileset with a memory copy instead of `composite()`

`composite()` is a general **N-layer alpha compositor**: its cost scales with the number of input layers (per-tile bounding-box math, pipeline setup, premultiplied-alpha blending), not with the pixels moved. Our tiles form a regular, **non-overlapping** grid on a transparent canvas, so placing them is just a memory copy. `renderTileset()` now assembles the destination RGBA buffer directly and encodes once.

## 3. Slice tiles from a cached raw source instead of per-tile `extract()`

Extracting each tile with its own `sharp.extract().raw()` call is thousands of round-trips into libvips over pixels we already hold. Each source tileset is now decoded to raw RGBA **once**, and tiles are copied straight from that cached buffer into the destination — fused into the assembly loop, so no per-tile buffer is allocated either.

## Results

Measured on a large map (`wa-headquarters`, 54,286 tiles, 8 chunks, compression off to isolate the effect):

| Stage | Original | This PR |
|---|---|---|
| get tile pixels | 21.8 s (per-tile extract) | **0.6 s** (decode source once) |
| assemble image | 65.7 s (`composite()`) | **0.3 s** (memory copy) |
| PNG encode | (folded into above) | 2.1 s |
| **Total** | **106 s** | **~5.6 s (~19×)** |

## Correctness

- The output `.tmj` is **identical**.
- **Alpha is bit-exact everywhere**, and **all fully-opaque pixels are bit-exact**.
- The only deviation from the pre-PR output is on **anti-aliased (semi-transparent) edge pixels**, which differ by **≤1/255** on a color channel. That is the rounding the old `composite()` path *introduced* by premultiplying then unpremultiplying alpha; the direct copy writes the exact source pixels, so the new output is if anything a *more* faithful reproduction of the source art. Visually indistinguishable. (Steps 2 and 3 are individually byte-for-byte identical to each other; this ≤1 difference comes solely from dropping `composite()` in step 2.)
- `npm run typecheck`: OK · `npm test`: 15/15 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)