### PR TITLE
ci: publish to npm via OIDC trusted publishing

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,20 +20,25 @@ jobs:
                 release-type: node
                 package-name: "wa-map-optimizer"
             # The logic below handles the npm publication:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v7
                 # these if statements ensure that a publication only occurs when
                 # a new release is created:
               if: ${{ steps.release.outputs.release_created }}
-            - uses: actions/setup-node@v1
+            - uses: actions/setup-node@v4
               with:
-                node-version: 20
+                node-version: 24
                 registry-url: 'https://registry.npmjs.org'
+              if: ${{ steps.release.outputs.release_created }}
+            # Trusted publishing (OIDC) requires npm >= 11.5.1, newer than the
+            # version bundled with the runner.
+            - run: npm install -g npm@latest
               if: ${{ steps.release.outputs.release_created }}
             - run: npm ci
               if: ${{ steps.release.outputs.release_created }}
             - run: npm run build
               if: ${{ steps.release.outputs.release_created }}
-            - run: npm publish --access public
-              env:
-                NODE_AUTH_TOKEN: ""
+            # No NODE_AUTH_TOKEN: authentication happens via OIDC, backed by the
+            # `id-token: write` permission and the trusted publisher configured
+            # for this package on npmjs.com.
+            - run: npm publish --provenance --access public
               if: ${{ steps.release.outputs.release_created }}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "license": "AGPL-3.0",
     "repository": {
         "type": "git",
-        "url": "https://github.com/nolway/wa-map-optimizer-vite"
+        "url": "https://github.com/nolway/wa-map-optimizer"
     },
     "types": "dist/index.d.ts",
     "files": [


### PR DESCRIPTION
## Problem

The `release-please` job fails at `npm publish` with:

```
npm error code ENEEDAUTH
npm error need auth This command requires you to be logged in to https://registry.npmjs.org/
```

The publish step set `NODE_AUTH_TOKEN: ""` (empty), so npm had no credentials. Token-based publishing is no longer the supported path — npm now uses **OIDC trusted publishing**.

## Changes

- Upgrade npm to `latest` before publishing (OIDC requires npm ≥ 11.5.1, newer than the runner's bundled npm).
- Drop the empty `NODE_AUTH_TOKEN` and publish with `--provenance`. Auth now flows through OIDC, backed by the existing `id-token: write` permission.
- Bump `actions/setup-node` and add the npm upgrade step.
- Fix `package.json` `repository.url` to point at this repo (it referenced `wa-map-optimizer-vite`); provenance verification requires it to match.

## Required manual step ⚠️

A **trusted publisher** must be configured for the package on npmjs.com, or publishing will still fail:

- Package settings → Trusted Publisher → **GitHub Actions**
- Owner: `Nolway`, Repository: `wa-map-optimizer`, Workflow: `release-please.yml`

This must be done by an npm owner/admin of the `wa-map-optimizer` package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)